### PR TITLE
Cleanup crosschain refs

### DIFF
--- a/docs/technical/01_addresses.md
+++ b/docs/technical/01_addresses.md
@@ -8,97 +8,78 @@
 |-----------|-----------------|-----------------|
 |   Kernel  |   Mainnet        | [`0x2286d7f9639e8158FaD1169e76d1FbC38247f54b`](https://etherscan.io/address/0x2286d7f9639e8158FaD1169e76d1FbC38247f54b) |
 |           |   Arbitrum       | [`0xeac3eC0CC130f4826715187805d1B50e861F2DaC`](https://arbiscan.io/address/0xeac3eC0CC130f4826715187805d1B50e861F2DaC) |
+|           |   Goerli       | [`0xDb7cf68154bd422dF5196D90285ceA057786b4c3`](https://goerli.etherscan.io/address/0xDb7cf68154bd422dF5196D90285ceA057786b4c3) |
+
 
 ### Modules
-
 | Contract | Chain | Address |
 | -------- | -------- | -------- |
 | TRSRY    | Mainnet | [`0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613`](https://etherscan.io/address/0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613) |
+|          | Goerli  | [`0xD8C59cFe5afbDB83D904E56D379028a2f6A07a2D`](https://goerli.etherscan.io/address/0xD8C59cFe5afbDB83D904E56D379028a2f6A07a2D) |
 | MINTR    | Mainnet  |  [`0xa90bFe53217da78D900749eb6Ef513ee5b6a491e`](https://etherscan.io/address/0xa90bFe53217da78D900749eb6Ef513ee5b6a491e) |
 |          | Arbitrum | [`0x8f6406eDbFA393e327822D4A08BcF15503570D87`](https://arbiscan.io/address/0x8f6406eDbFA393e327822D4A08BcF15503570D87) |
+|          | Goerli   | [`0xa192fFBF73858831a137DD098a706139Ca96AbD5`](https://goerli.etherscan.io/address/0xa192fFBF73858831a137DD098a706139Ca96AbD5) |
 | PRICE    | Mainnet | [`0xd6C4D723fdadCf0D171eF9A2a3Bfa870675b282f`](https://etherscan.io/address/0xd6C4D723fdadCf0D171eF9A2a3Bfa870675b282f) |
-| RANGE    | Mainnet| [`0xb212D9584cfc56EFf1117F412Fe0bBdc53673954`](https://etherscan.io/address/0xb212D9584cfc56EFf1117F412Fe0bBdc53673954) |
+|          | Goerli  | [`0xD9ace3Be2d80006EF4D90A2D35D861a5C9F98252`](https://goerli.etherscan.io/address/0xD9ace3Be2d80006EF4D90A2D35D861a5C9F98252) |
+| RANGE    | Mainnet | [`0xb212D9584cfc56EFf1117F412Fe0bBdc53673954`](https://etherscan.io/address/0xb212D9584cfc56EFf1117F412Fe0bBdc53673954) |
+|          | Goerli  | [`0x446f06f8Df7d5f627B073c6349b948B95c1f9185`](https://goerli.etherscan.io/address/0x446f06f8Df7d5f627B073c6349b948B95c1f9185) |
 | ROLES    | Mainnet  | [`0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59`](https://etherscan.io/address/0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59) |
 |          | Arbitrum | [`0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6`](https://arbiscan.io/address/0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6) |
+|          | Goerli   | [`0xe9a9d80CE3eE32FFf7279dce4c2962eC8098f71B`](https://goerli.etherscan.io/address/0xe9a9d80CE3eE32FFf7279dce4c2962eC8098f71B) |
 | BLREG    | Mainnet | [`0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59`](https://etherscan.io/address/0x375E06C694B5E50aF8be8FB03495A612eA3e2275) |
+|          | Goerli  | [`0x24963bEA5a156E3dAb8aBA4FCB8a2dBE8c1Aaa14`](https://goerli.etherscan.io/address/0x24963bEA5a156E3dAb8aBA4FCB8a2dBE8c1Aaa14) |
+
+
+
+
 
 
 ### Policies
-
 | Contract | Chain | Address |
 | -------- | ----  | ------- |
 | BondCallback       | Mainnet |  [`0xbf2B6E99B0E8D4c96b946c182132f5752eAa55C6`](https://etherscan.io/address/0xbf2B6E99B0E8D4c96b946c182132f5752eAa55C6) |
+|                    | Goerli  | [`0xC1545804Fb804fdC7756e8e40c91B7581b2a2856`](https://goerli.etherscan.io/address/0xC1545804Fb804fdC7756e8e40c91B7581b2a2856) |
 | Operator           | Mainnet | [`0x1Ce568DbB34B2631aCDB5B453c3195EA0070EC65`](https://etherscan.io/address/0x1Ce568DbB34B2631aCDB5B453c3195EA0070EC65) |
+|                    | Goerli  | [`0x61B79d10ebC48166F7495Fce5E0c352B61777460`](https://goerli.etherscan.io/address/0x61B79d10ebC48166F7495Fce5E0c352B61777460) |
 | Heart              | Mainnet | [`0x1652b503E0F1CF38b6246Ed3b91CB3786Bb11656`](https://etherscan.io/address/0x1652b503E0F1CF38b6246Ed3b91CB3786Bb11656) |
+|                    | Goerli  | [`0x384c7AeFB9f7aF276CF717905A696F85E2dD8845`](https://goerli.etherscan.io/address/0x384c7AeFB9f7aF276CF717905A696F85E2dD8845) |
 | PriceConfig        | Mainnet | [`0xf6D5d06A4e8e6904E4360108749C177692F59E90`](https://etherscan.io/address/0xf6D5d06A4e8e6904E4360108749C177692F59E90) |
+|                    | Goerli  | [`0x15915Be9d272B353BA06FA5Ce3918ae7D27F5463`](https://goerli.etherscan.io/address/0x15915Be9d272B353BA06FA5Ce3918ae7D27F5463) |
 | RolesAdmin         | Mainnet  | [`0xb216d714d91eeC4F7120a732c11428857C659eC8`](https://etherscan.io/address/0xb216d714d91eeC4F7120a732c11428857C659eC8) |
 |                    | Arbitrum | [`0x69168c08AcF66f002fd02E1B169f38C022c93b70`](https://arbiscan.io/address/0x69168c08AcF66f002fd02E1B169f38C022c93b70) |
+|                    | Goerli   | [`0x54FfCA586cD1B01E96a5682DF93a55d7Ef91EFF0`](https://goerli.etherscan.io/address/0x54FfCA586cD1B01E96a5682DF93a55d7Ef91EFF0) |
 | TreasuryCustodian  | Mainnet | [`0xC9518AC915e46D707585116451Dc19c164513Ccf`](https://etherscan.io/address/0xC9518AC915e46D707585116451Dc19c164513Ccf) |
+|                    | Goerli  | [`0x3DAE418f8B6382b3d3d0cb9008924BA83D2e0E87`](https://goerli.etherscan.io/address/0x3DAE418f8B6382b3d3d0cb9008924BA83D2e0E87) |
 | Distributor        | Mainnet | [`0x27e606fdb5C922F8213dC588A434BF7583697866`](https://etherscan.io/address/0x27e606fdb5C922F8213dC588A434BF7583697866) |
+|                    | Goerli  | [`0x2716a1451BDE2B011f0D10ad6599e411d54Ec491`](https://goerli.etherscan.io/address/0x2716a1451BDE2B011f0D10ad6599e411d54Ec491) |
 | Emergency          | Mainnet | [`0x9229b0b6FA4A58D67Eb465567DaA2c6A34714A75`](https://etherscan.io/address/0x9229b0b6FA4A58D67Eb465567DaA2c6A34714A75) |
+|                    | Goerli  | [`0x196a59fB453da942f062Be4407D923129c759435`](https://goerli.etherscan.io/address/0x196a59fB453da942f062Be4407D923129c759435) |
 | BondManager        | Mainnet | [`0xf577c77ee3578c7F216327F41B5D7221EaD2B2A3`](https://etherscan.io/address/0xf577c77ee3578c7f216327f41b5d7221ead2b2a3) |
+|                    | Goerli  | [`0x1e5a6834A71770067fcCbAeDDBC86b6d8dFDCb27`](https://goerli.etherscan.io/address/0x1e5a6834A71770067fcCbAeDDBC86b6d8dFDCb27) |
 | BLVaultManagerLido | Mainnet | [`0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23`](https://etherscan.io/address/0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23) |
+|                    | Goerli  | [`0x5c9352d333F4D9EA1FDbF374d8D392e1843D0E34`](https://goerli.etherscan.io/address/0x5c9352d333F4D9EA1FDbF374d8D392e1843D0E34) |
 | CrossChainBridge   | Mainnet  | [`0x45e563c39cddba8699a90078f42353a57509543a`](https://etherscan.io/address/0x45e563c39cddba8699a90078f42353a57509543a) |
 |                    | Arbitrum | [`0x20B3834091f038Ce04D8686FAC99CA44A0FB285c`](https://arbiscan.io/address/0x20B3834091f038Ce04D8686FAC99CA44A0FB285c) | 
+| Faucet (Testnet only) | Goerli | [`0xA247156a39169c0FAFf979F57361CC734e82e3d0`](https://goerli.etherscan.io/address/0xA247156a39169c0FAFf979F57361CC734e82e3d0) |
+
 
 
 ### Dependencies
-
 | Contract    | Chain | Address |
 | ----------- | ----- | ------- |
 | BondTeller | Mainnet | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
+|            | Goerli | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://goerli.etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
 | Authority | Arbitrum | [`0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e`](https://arbiscan.io/address/0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e) |
-
-
-### Goerli Testnet
-
-| Contract | Address                                                                                                                        |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Kernel   | [`0xDb7cf68154bd422dF5196D90285ceA057786b4c3`](https://goerli.etherscan.io/address/0xDb7cf68154bd422dF5196D90285ceA057786b4c3) |
-
-#### Modules
-
-| Contract | Address                                                                                                                        |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| TRSRY    | [`0xD8C59cFe5afbDB83D904E56D379028a2f6A07a2D`](https://goerli.etherscan.io/address/0xD8C59cFe5afbDB83D904E56D379028a2f6A07a2D) |
-| MINTR    | [`0xa192fFBF73858831a137DD098a706139Ca96AbD5`](https://goerli.etherscan.io/address/0xa192fFBF73858831a137DD098a706139Ca96AbD5) |
-| PRICE    | [`0xD9ace3Be2d80006EF4D90A2D35D861a5C9F98252`](https://goerli.etherscan.io/address/0xD9ace3Be2d80006EF4D90A2D35D861a5C9F98252) |
-| RANGE    | [`0x446f06f8Df7d5f627B073c6349b948B95c1f9185`](https://goerli.etherscan.io/address/0x446f06f8Df7d5f627B073c6349b948B95c1f9185) |
-| ROLES    | [`0xe9a9d80CE3eE32FFf7279dce4c2962eC8098f71B`](https://goerli.etherscan.io/address/0xe9a9d80CE3eE32FFf7279dce4c2962eC8098f71B) |
-| BLREG    | [`0x24963bEA5a156E3dAb8aBA4FCB8a2dBE8c1Aaa14`](https://goerli.etherscan.io/address/0x24963bEA5a156E3dAb8aBA4FCB8a2dBE8c1Aaa14) |
-
-#### Policies
-
-| Contract              | Address                                                                                                                        |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| BondCallback          | [`0xC1545804Fb804fdC7756e8e40c91B7581b2a2856`](https://goerli.etherscan.io/address/0xC1545804Fb804fdC7756e8e40c91B7581b2a2856) |
-| Heart                 | [`0x384c7AeFB9f7aF276CF717905A696F85E2dD8845`](https://goerli.etherscan.io/address/0x384c7AeFB9f7aF276CF717905A696F85E2dD8845) |
-| Operator              | [`0x61B79d10ebC48166F7495Fce5E0c352B61777460`](https://goerli.etherscan.io/address/0x61B79d10ebC48166F7495Fce5E0c352B61777460) |
-| PriceConfig           | [`0x15915Be9d272B353BA06FA5Ce3918ae7D27F5463`](https://goerli.etherscan.io/address/0x15915Be9d272B353BA06FA5Ce3918ae7D27F5463) |
-| TreasuryCustodian     | [`0x3DAE418f8B6382b3d3d0cb9008924BA83D2e0E87`](https://goerli.etherscan.io/address/0x3DAE418f8B6382b3d3d0cb9008924BA83D2e0E87) |
-| Distributor           | [`0x2716a1451BDE2B011f0D10ad6599e411d54Ec491`](https://goerli.etherscan.io/address/0x2716a1451BDE2B011f0D10ad6599e411d54Ec491) |
-| RolesAdmin            | [`0x54FfCA586cD1B01E96a5682DF93a55d7Ef91EFF0`](https://goerli.etherscan.io/address/0x54FfCA586cD1B01E96a5682DF93a55d7Ef91EFF0) |
-| Emergency             | [`0x196a59fB453da942f062Be4407D923129c759435`](https://goerli.etherscan.io/address/0x196a59fB453da942f062Be4407D923129c759435) |
-| Faucet (Testnet only) | [`0xA247156a39169c0FAFf979F57361CC734e82e3d0`](https://goerli.etherscan.io/address/0xA247156a39169c0FAFf979F57361CC734e82e3d0) |
-| BondManager           | [`0x1e5a6834A71770067fcCbAeDDBC86b6d8dFDCb27`](https://goerli.etherscan.io/address/0x1e5a6834A71770067fcCbAeDDBC86b6d8dFDCb27) |
-| BLVaultManagerLido    | [`0x5c9352d333F4D9EA1FDbF374d8D392e1843D0E34`](https://goerli.etherscan.io/address/0x5c9352d333F4D9EA1FDbF374d8D392e1843D0E34) |
-
-#### Dependencies
-
-| Contract                        | Address                                                                                                                        |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| OHM Token                       | [`0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b`](https://goerli.etherscan.io/address/0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b) |
-| DAI Token                       | [`0x41e38e70a36150D08A8c97aEC194321b5eB545A5`](https://goerli.etherscan.io/address/0x41e38e70a36150D08A8c97aEC194321b5eB545A5) |
-| OHM-DAI Balancer LP Pool        | [`0xd8833594420dB3D6589c1098dbDd073f52419Dba`](https://goerli.etherscan.io/address/0xd8833594420dB3D6589c1098dbDd073f52419Dba) |
-| WETH Token (for keeper rewards) | [`0x0Bb7509324cE409F7bbC4b701f932eAca9736AB7`](https://goerli.etherscan.io/address/0x0Bb7509324cE409F7bbC4b701f932eAca9736AB7) |
-| Mock OHM/ETH Price Feed         | [`0x022710a589C9796dce59A0C52cA4E36f0a5e991A`](https://goerli.etherscan.io/address/0x022710a589C9796dce59A0C52cA4E36f0a5e991A) |
-| Mock DAI/ETH Price Feed         | [`0xdC8E4eD326cFb730a759312B6b1727C6Ef9ca233`](https://goerli.etherscan.io/address/0xdC8E4eD326cFb730a759312B6b1727C6Ef9ca233) |
-| Bond Auctioneer                 | [`0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222`](https://goerli.etherscan.io/address/0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222) |
-| Bond Teller                     | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://goerli.etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
-| Bond Aggregator                 | [`0x007A66A2a13415DB3613C1a4dd1C942A285902d1`](https://goerli.etherscan.io/address/0x007A66A2a13415DB3613C1a4dd1C942A285902d1) |
+| OHM Token | Goerli   | [`0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b`](https://goerli.etherscan.io/address/0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b) |
+| DAI Token | Goerli   | [`0x41e38e70a36150D08A8c97aEC194321b5eB545A5`](https://goerli.etherscan.io/address/0x41e38e70a36150D08A8c97aEC194321b5eB545A5) |
+| OHM-DAI Balancer LP Pool | Goerli | [`0xd8833594420dB3D6589c1098dbDd073f52419Dba`](https://goerli.etherscan.io/address/0xd8833594420dB3D6589c1098dbDd073f52419Dba) |
+| WETH Token (for keeper rewards) | Goerli | [`0x0Bb7509324cE409F7bbC4b701f932eAca9736AB7`](https://goerli.etherscan.io/address/0x0Bb7509324cE409F7bbC4b701f932eAca9736AB7) |
+| Mock OHM/ETH Price Feed         | Goerli | [`0x022710a589C9796dce59A0C52cA4E36f0a5e991A`](https://goerli.etherscan.io/address/0x022710a589C9796dce59A0C52cA4E36f0a5e991A) |
+| Mock DAI/ETH Price Feed         | Goerli | [`0xdC8E4eD326cFb730a759312B6b1727C6Ef9ca233`](https://goerli.etherscan.io/address/0xdC8E4eD326cFb730a759312B6b1727C6Ef9ca233) |
+| Bond Auctioneer                 | Goerli | [`0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222`](https://goerli.etherscan.io/address/0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222) |
+| Bond Aggregator                 | Goerli | [`0x007A66A2a13415DB3613C1a4dd1C942A285902d1`](https://goerli.etherscan.io/address/0x007A66A2a13415DB3613C1a4dd1C942A285902d1) |
 
 #### Privileged Testnet Accounts (Multi-sigs)
-
 | Contract  | Address                                                                                                                        |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | Executor  | [`0x84C0C005cF574D0e5C602EA7b366aE9c707381E0`](https://goerli.etherscan.io/address/0x84C0C005cF574D0e5C602EA7b366aE9c707381E0) |

--- a/docs/technical/01_addresses.md
+++ b/docs/technical/01_addresses.md
@@ -26,7 +26,7 @@
 | ROLES    | Mainnet  | [`0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59`](https://etherscan.io/address/0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59) |
 |          | Arbitrum | [`0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6`](https://arbiscan.io/address/0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6) |
 |          | Goerli   | [`0xe9a9d80CE3eE32FFf7279dce4c2962eC8098f71B`](https://goerli.etherscan.io/address/0xe9a9d80CE3eE32FFf7279dce4c2962eC8098f71B) |
-| BLREG    | Mainnet | [`0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59`](https://etherscan.io/address/0x375E06C694B5E50aF8be8FB03495A612eA3e2275) |
+| BLREG    | Mainnet | [`0x375E06C694B5E50aF8be8FB03495A612eA3e2275`](https://etherscan.io/address/0x375E06C694B5E50aF8be8FB03495A612eA3e2275) |
 |          | Goerli  | [`0x24963bEA5a156E3dAb8aBA4FCB8a2dBE8c1Aaa14`](https://goerli.etherscan.io/address/0x24963bEA5a156E3dAb8aBA4FCB8a2dBE8c1Aaa14) |
 
 

--- a/docs/technical/01_addresses.md
+++ b/docs/technical/01_addresses.md
@@ -69,8 +69,40 @@
 | ----------- | ----- | ------- |
 | BondTeller | Mainnet | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
 |            | Goerli | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://goerli.etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
+
+
+### Legacy Contracts
+| Contract    | Chain | Address |
+| ----------- | ----- | ------- |
+| OHM V2      | Mainnet | [`0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5`](https://etherscan.io/address/0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5) |
+|             | Arbitrum  | [`0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028`](https://arbiscan.io/token/0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028)             |
+|             | Goerli   | [`0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b`](https://goerli.etherscan.io/address/0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b) |
+| sOHM V2     | Mainnet | [`0x04906695D6D12CF5459975d7C3C03356E4Ccd460`](https://etherscan.io/address/0x04906695D6D12CF5459975d7C3C03356E4Ccd460) |
+|             | Goerli  | [`0x4EFe119F4949319f2Acb12efD615a7B63896482B`](https://goerli.etherscan.io/address/0x4EFe119F4949319f2Acb12efD615a7B63896482B) |
+| gOHM | Mainnet | [`0x0ab87046fBb341D058F17CBC4c1133F25a20a52f`](https://etherscan.io/address/0x0ab87046fBb341D058F17CBC4c1133F25a20a52f) |
+|      | Arbitrum  | [`0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1`](https://arbiscan.io/token/0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1)             |
+|      | Avalanche | [`0x321e7092a180bb43555132ec53aaa65a5bf84251`](https://snowtrace.io/token/0x321e7092a180bb43555132ec53aaa65a5bf84251)            |
+|      | Polygon   | [`0xd8cA34fd379d9ca3C6Ee3b3905678320F5b45195`](https://polygonscan.com/token/0xd8cA34fd379d9ca3C6Ee3b3905678320F5b45195)         |
+|      | Fantom    | [`0x91fa20244fb509e8289ca630e5db3e9166233fdc`](https://ftmscan.com/token/0x91fa20244fb509e8289ca630e5db3e9166233fdc)             |
+|      | Optimism  | [`0x0b5740c6b4a97f90eF2F0220651Cca420B868FfB`](https://optimistic.etherscan.io/token/0x0b5740c6b4a97f90eF2F0220651Cca420B868FfB) |
+|      | Boba      | [`0xd22C0a4Af486C7FA08e282E9eB5f30F9AaA62C95`](https://bobascan.com/token/0xd22C0a4Af486C7FA08e282E9eB5f30F9AaA62C95)            |
+|      | Goerli  | [`0xC1863141dc1861122d5410fB5973951c82871d98`](https://goerli.etherscan.io/address/0xC1863141dc1861122d5410fB5973951c82871d98) |
+| Staking | Mainnet | [`0xB63cac384247597756545b500253ff8E607a8020`](https://etherscan.io/address/0xB63cac384247597756545b500253ff8E607a8020) |
+|         | Goerli  | [`0x7263372b9ff6E619d8774aEB046cE313677E2Ec7`](https://goerli.etherscan.io/address/0x7263372b9ff6E619d8774aEB046cE313677E2Ec7) |
+| Treasury V2 | Mainnet | [`0x9A315BdF513367C0377FB36545857d12e85813Ef`](https://etherscan.io/address/0x9A315BdF513367C0377FB36545857d12e85813Ef) |
+|             | Goerli  | [`0xB3e1dF7951a62fFb5eF7D3b1C9D80CF09325580A`](https://goerli.etherscan.io/address/0xB3e1dF7951a62fFb5eF7D3b1C9D80CF09325580A) |
+| TreasuryExtender | Mainnet | [`0xb32Ad041f23eAfd682F57fCe31d3eA4fd92D17af`](https://etherscan.io/address/0xb32Ad041f23eAfd682F57fCe31d3eA4fd92D17af) |
+| Distributor | Mainnet | [`0xeeeb97A127a342656191E0313DF33D58D06B2E05`](https://etherscan.io/address/0xeeeb97A127a342656191E0313DF33D58D06B2E05) |
+|             | Goerli  | [`0x2b954551307FB929DF8BB96657DB69fB4d72617c`](https://goerli.etherscan.io/address/0x2b954551307FB929DF8BB96657DB69fB4d72617c) |
+| BondDepositoryV2 | Mainnet | [`0x9025046c6fb25Fb39e720d97a8FD881ED69a1Ef6`](https://etherscan.io/address/0x9025046c6fb25Fb39e720d97a8FD881ED69a1Ef6) |
+|                  | Goerli  | [`0xAda3336fcD233Ff0Eb39BeA0b1a7784E43aD4B00`](https://goerli.etherscan.io/address/0xAda3336fcD233Ff0Eb39BeA0b1a7784E43aD4B00) |
+| Authority | Mainnet | [`0x1c21F8EA7e39E2BA00BC12d2968D63F4acb38b7A`](https://etherscan.io/address/0x1c21F8EA7e39E2BA00BC12d2968D63F4acb38b7A) |
+| YieldDirector | Mainnet | [`0x2604170762A1dD22BB4F96C963043Cd4FC358f18`](https://etherscan.io/address/0x2604170762A1dD22BB4F96C963043Cd4FC358f18) |
+|               | Goerli  | [`0x6982CcD55F95A7469746C123f73D54377f382454`](https://goerli.etherscan.io/address/0x6982CcD55F95A7469746C123f73D54377f382454) |
+| OP Market Creator (for inverse bonds) (old) | Mainnet | [`0xb1fA0Ac44d399b778B14af0AAF4bCF8af3437ad1`](https://etherscan.io/address/0xb1fA0Ac44d399b778B14af0AAF4bCF8af3437ad1) |
+| | Goerli | [`0x0C9D01FbD07cC2fD3e09bD953bb65698351AF05D`](https://goerli.etherscan.io/address/0x0C9D01FbD07cC2fD3e09bD953bb65698351AF05D) |
 | Authority | Arbitrum | [`0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e`](https://arbiscan.io/address/0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e) |
-| OHM Token | Goerli   | [`0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b`](https://goerli.etherscan.io/address/0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b) |
+|           | Goerli   | [`0x4A8c9502A34962a2C6d73c5D181dAaeF3dcDc88D`](https://goerli.etherscan.io/address/0x4A8c9502A34962a2C6d73c5D181dAaeF3dcDc88D) |
 | DAI Token | Goerli   | [`0x41e38e70a36150D08A8c97aEC194321b5eB545A5`](https://goerli.etherscan.io/address/0x41e38e70a36150D08A8c97aEC194321b5eB545A5) |
 | OHM-DAI Balancer LP Pool | Goerli | [`0xd8833594420dB3D6589c1098dbDd073f52419Dba`](https://goerli.etherscan.io/address/0xd8833594420dB3D6589c1098dbDd073f52419Dba) |
 | WETH Token (for keeper rewards) | Goerli | [`0x0Bb7509324cE409F7bbC4b701f932eAca9736AB7`](https://goerli.etherscan.io/address/0x0Bb7509324cE409F7bbC4b701f932eAca9736AB7) |
@@ -78,6 +110,10 @@
 | Mock DAI/ETH Price Feed         | Goerli | [`0xdC8E4eD326cFb730a759312B6b1727C6Ef9ca233`](https://goerli.etherscan.io/address/0xdC8E4eD326cFb730a759312B6b1727C6Ef9ca233) |
 | Bond Auctioneer                 | Goerli | [`0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222`](https://goerli.etherscan.io/address/0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222) |
 | Bond Aggregator                 | Goerli | [`0x007A66A2a13415DB3613C1a4dd1C942A285902d1`](https://goerli.etherscan.io/address/0x007A66A2a13415DB3613C1a4dd1C942A285902d1) |
+
+
+
+### Goerli
 
 #### Privileged Testnet Accounts (Multi-sigs)
 | Contract  | Address                                                                                                                        |
@@ -98,39 +134,6 @@
 | Uniswap Strategy                | [`0x39D1984051759830F0C0Ae979b4aEd776CF481E0`](https://etherscan.io/address/0x39D1984051759830F0C0Ae979b4aEd776CF481E0) |
 | Sushiswap Strategy              | [`0x0692bDcAa767Dc62C420B7893a1045E657771324`](https://etherscan.io/address/0x0692bDcAa767Dc62C420B7893a1045E657771324) |
 | Balancer Strategy               | [`0x48BdC486C9DF31848C62FDc85c5c77d4Be013cDC`](https://etherscan.io/address/0x48BdC486C9DF31848C62FDc85c5c77d4Be013cDC) |
-
-## Legacy/Old Contracts
-
-### Mainnet
-
-| Contract                                    | Address                                                                                                                 |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| OHM V2                                      | [`0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5`](https://etherscan.io/address/0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5) |
-| sOHM V2                                     | [`0x04906695D6D12CF5459975d7C3C03356E4Ccd460`](https://etherscan.io/address/0x04906695D6D12CF5459975d7C3C03356E4Ccd460) |
-| gOHM                                        | [`0x0ab87046fBb341D058F17CBC4c1133F25a20a52f`](https://etherscan.io/address/0x0ab87046fBb341D058F17CBC4c1133F25a20a52f) |
-| Staking                                     | [`0xB63cac384247597756545b500253ff8E607a8020`](https://etherscan.io/address/0xB63cac384247597756545b500253ff8E607a8020) |
-| Treasury V2                                 | [`0x9A315BdF513367C0377FB36545857d12e85813Ef`](https://etherscan.io/address/0x9A315BdF513367C0377FB36545857d12e85813Ef) |
-| TreasuryExtender                            | [`0xb32Ad041f23eAfd682F57fCe31d3eA4fd92D17af`](https://etherscan.io/address/0xb32Ad041f23eAfd682F57fCe31d3eA4fd92D17af) |
-| Distributor                                 | [`0xeeeb97A127a342656191E0313DF33D58D06B2E05`](https://etherscan.io/address/0xeeeb97A127a342656191E0313DF33D58D06B2E05) |
-| BondDepositoryV2                            | [`0x9025046c6fb25Fb39e720d97a8FD881ED69a1Ef6`](https://etherscan.io/address/0x9025046c6fb25Fb39e720d97a8FD881ED69a1Ef6) |
-| Authority                                   | [`0x1c21F8EA7e39E2BA00BC12d2968D63F4acb38b7A`](https://etherscan.io/address/0x1c21F8EA7e39E2BA00BC12d2968D63F4acb38b7A) |
-| YieldDirector                               | [`0x2604170762A1dD22BB4F96C963043Cd4FC358f18`](https://etherscan.io/address/0x2604170762A1dD22BB4F96C963043Cd4FC358f18) |
-| OP Market Creator (for inverse bonds) (old) | [`0xb1fA0Ac44d399b778B14af0AAF4bCF8af3437ad1`](https://etherscan.io/address/0xb1fA0Ac44d399b778B14af0AAF4bCF8af3437ad1) |
-
-### Goerli
-
-| Contract                                    | Address                                                                                                                        |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| OHM V2                                      | [`0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b`](https://goerli.etherscan.io/address/0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b) |
-| sOHM V2                                     | [`0x4EFe119F4949319f2Acb12efD615a7B63896482B`](https://goerli.etherscan.io/address/0x4EFe119F4949319f2Acb12efD615a7B63896482B) |
-| gOHM                                        | [`0xC1863141dc1861122d5410fB5973951c82871d98`](https://goerli.etherscan.io/address/0xC1863141dc1861122d5410fB5973951c82871d98) |
-| Staking                                     | [`0x7263372b9ff6E619d8774aEB046cE313677E2Ec7`](https://goerli.etherscan.io/address/0x7263372b9ff6E619d8774aEB046cE313677E2Ec7) |
-| Treasury V2                                 | [`0xB3e1dF7951a62fFb5eF7D3b1C9D80CF09325580A`](https://goerli.etherscan.io/address/0xB3e1dF7951a62fFb5eF7D3b1C9D80CF09325580A) |
-| Distributor                                 | [`0x2b954551307FB929DF8BB96657DB69fB4d72617c`](https://goerli.etherscan.io/address/0x2b954551307FB929DF8BB96657DB69fB4d72617c) |
-| BondDepositoryV2                            | [`0xAda3336fcD233Ff0Eb39BeA0b1a7784E43aD4B00`](https://goerli.etherscan.io/address/0xAda3336fcD233Ff0Eb39BeA0b1a7784E43aD4B00) |
-| Authority                                   | [`0x4A8c9502A34962a2C6d73c5D181dAaeF3dcDc88D`](https://goerli.etherscan.io/address/0x4A8c9502A34962a2C6d73c5D181dAaeF3dcDc88D) |
-| YieldDirector                               | [`0x6982CcD55F95A7469746C123f73D54377f382454`](https://goerli.etherscan.io/address/0x6982CcD55F95A7469746C123f73D54377f382454) |
-| OP Market Creator (for inverse bonds) (old) | [`0x0C9D01FbD07cC2fD3e09bD953bb65698351AF05D`](https://goerli.etherscan.io/address/0x0C9D01FbD07cC2fD3e09bD953bb65698351AF05D) |
 
 ## Allocators
 
@@ -158,16 +161,3 @@
 | Policy   | Ethereum  | [`0x0cf30dc0d48604A301dF8010cdc028C055336b2E`](https://etherscan.io/address/0x0cf30dc0d48604A301dF8010cdc028C055336b2E)    |
 | DAO      | Optimism | [`0x559a14a2219Ae81f9a9f857CF31407de2b07F36c`](https://optimistic.etherscan.io/address/0x559a14a2219Ae81f9a9f857CF31407de2b07F36c) |    
 |
-
-
-## Cross-Chain
-
-| Contract  | Chain     | Address                                                                                                                          |
-| --------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| OHM ERC20 | Arbitrum  | [`0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028`](https://arbiscan.io/token/0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028)             |
-| gOHM      | Arbitrum  | [`0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1`](https://arbiscan.io/token/0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1)             |
-| gOHM      | Avalanche | [`0x321e7092a180bb43555132ec53aaa65a5bf84251`](https://snowtrace.io/token/0x321e7092a180bb43555132ec53aaa65a5bf84251)            |
-| gOHM      | Polygon   | [`0xd8cA34fd379d9ca3C6Ee3b3905678320F5b45195`](https://polygonscan.com/token/0xd8cA34fd379d9ca3C6Ee3b3905678320F5b45195)         |
-| gOHM      | Fantom    | [`0x91fa20244fb509e8289ca630e5db3e9166233fdc`](https://ftmscan.com/token/0x91fa20244fb509e8289ca630e5db3e9166233fdc)             |
-| gOHM      | Optimism  | [`0x0b5740c6b4a97f90eF2F0220651Cca420B868FfB`](https://optimistic.etherscan.io/token/0x0b5740c6b4a97f90eF2F0220651Cca420B868FfB) |
-| gOHM      | Boba      | [`0xd22C0a4Af486C7FA08e282E9eB5f30F9AaA62C95`](https://bobascan.com/token/0xd22C0a4Af486C7FA08e282E9eB5f30F9AaA62C95)            |

--- a/docs/technical/01_addresses.md
+++ b/docs/technical/01_addresses.md
@@ -41,22 +41,14 @@
 | CrossChainBridge   | Mainnet  | [`0x45e563c39cddba8699a90078f42353a57509543a`](https://etherscan.io/address/0x45e563c39cddba8699a90078f42353a57509543a) |
 |                    | Arbitrum | [`0x20B3834091f038Ce04D8686FAC99CA44A0FB285c`](https://arbiscan.io/address/0x20B3834091f038Ce04D8686FAC99CA44A0FB285c) | 
 
-#### Dependencies
 
-| Contract    | Address                                                                                                                 |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Bond Teller | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
+### Dependencies
 
-### Arbitrum
+| Contract    | Chain | Address |
+| ----------- | ----- | ------- |
+| BondTeller | Mainnet | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
+| Authority | Arbitrum | [`0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e`](https://arbiscan.io/address/0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e) |
 
-
-### Arbitrum
-
-#### Dependencies
-
-| Contract  | Address                                                                                                                |
-| --------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Authority | [`0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e`](https://arbiscan.io/address/0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e) |
 
 ### Goerli Testnet
 

--- a/docs/technical/01_addresses.md
+++ b/docs/technical/01_addresses.md
@@ -2,11 +2,12 @@
 
 ## Olympus V3 Contracts
 
-### Mainnet
+### Kernel
 
-| Contract | Address                                                                                                                 |
-| -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Kernel   | [`0x2286d7f9639e8158FaD1169e76d1FbC38247f54b`](https://etherscan.io/address/0x2286d7f9639e8158FaD1169e76d1FbC38247f54b) |
+|   Contract   |   Chain   | Address |
+|-----------|-----------------|-----------------|
+|   Kernel  |   Mainnet        | [`0x2286d7f9639e8158FaD1169e76d1FbC38247f54b`](https://etherscan.io/address/0x2286d7f9639e8158FaD1169e76d1FbC38247f54b) |
+|           |   Arbitrum       | [`0xeac3eC0CC130f4826715187805d1B50e861F2DaC`](https://arbiscan.io/address/0xeac3eC0CC130f4826715187805d1B50e861F2DaC) |
 
 #### Modules
 
@@ -42,10 +43,6 @@
 | Bond Teller | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
 
 ### Arbitrum
-
-| Contract | Address                                                                                                                |
-| -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Kernel   | [`0xeac3eC0CC130f4826715187805d1B50e861F2DaC`](https://arbiscan.io/address/0xeac3eC0CC130f4826715187805d1B50e861F2DaC) |
 
 #### Modules
 

--- a/docs/technical/01_addresses.md
+++ b/docs/technical/01_addresses.md
@@ -112,29 +112,6 @@
 | Bond Aggregator                 | Goerli | [`0x007A66A2a13415DB3613C1a4dd1C942A285902d1`](https://goerli.etherscan.io/address/0x007A66A2a13415DB3613C1a4dd1C942A285902d1) |
 
 
-
-### Goerli
-
-#### Privileged Testnet Accounts (Multi-sigs)
-| Contract  | Address                                                                                                                        |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Executor  | [`0x84C0C005cF574D0e5C602EA7b366aE9c707381E0`](https://goerli.etherscan.io/address/0x84C0C005cF574D0e5C602EA7b366aE9c707381E0) |
-| Guardian  | [`0x84C0C005cF574D0e5C602EA7b366aE9c707381E0`](https://goerli.etherscan.io/address/0x84C0C005cF574D0e5C602EA7b366aE9c707381E0) |
-| Policy    | [`0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7`](https://goerli.etherscan.io/address/0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7) |
-| Emergency | [`0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7`](https://goerli.etherscan.io/address/0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7) |
-
-## Periphery Contracts
-
-### Flex Loans
-
-| Contract                        | Address                                                                                                                 |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Flex Loan contract (Incur Debt) | [`0xd9d87586774Fb9d036fa95A5991474513Ff6C96E`](https://etherscan.io/address/0xd9d87586774Fb9d036fa95A5991474513Ff6C96E) |
-| Curve Strategy                  | [`0x4B152CCB613Ee248df9bb98195bC505665D6C4b2`](https://etherscan.io/address/0x4B152CCB613Ee248df9bb98195bC505665D6C4b2) |
-| Uniswap Strategy                | [`0x39D1984051759830F0C0Ae979b4aEd776CF481E0`](https://etherscan.io/address/0x39D1984051759830F0C0Ae979b4aEd776CF481E0) |
-| Sushiswap Strategy              | [`0x0692bDcAa767Dc62C420B7893a1045E657771324`](https://etherscan.io/address/0x0692bDcAa767Dc62C420B7893a1045E657771324) |
-| Balancer Strategy               | [`0x48BdC486C9DF31848C62FDc85c5c77d4Be013cDC`](https://etherscan.io/address/0x48BdC486C9DF31848C62FDc85c5c77d4Be013cDC) |
-
 ## Allocators
 
 | Contract         | Address                                                                                                                 |
@@ -154,10 +131,25 @@
 | Contract | Chain     | Address                                                                                                                    |
 | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
 | DAO      | Ethereum  | [`0x245cc372C84B3645Bf0Ffe6538620B04a217988B`](https://etherscan.io/address/0x245cc372C84B3645Bf0Ffe6538620B04a217988B)    |
-| DAO      | Arbitrum  | [`0x012BBf0481b97170577745D2167ee14f63E2aD4C`](https://arbiscan.io/address/0x012BBf0481b97170577745D2167ee14f63E2aD4C)     |
-| DAO      | Polygon   | [`0xe06efA3D9Ee6923240ee1195A16ddd96B5CcE8F7`](https://polygonscan.com/address/0xe06efA3D9Ee6923240ee1195A16ddd96B5CcE8F7) |
-| DAO      | Fantom    | [`0x2bC001fFEB862d843e0a02a7163C7d4828e5FB10`](https://ftmscan.com/address/0x2bC001fFEB862d843e0a02a7163C7d4828e5FB10)     |
-| DAO      | Avalanche | [`0xD1f617fDC0E2e7aF49f7250f163095E76F8e4B32`](https://snowtrace.io/address/0xD1f617fDC0E2e7aF49f7250f163095E76F8e4B32)    |
+|          | Arbitrum  | [`0x012BBf0481b97170577745D2167ee14f63E2aD4C`](https://arbiscan.io/address/0x012BBf0481b97170577745D2167ee14f63E2aD4C)     |
+|          | Optimism | [`0x559a14a2219Ae81f9a9f857CF31407de2b07F36c`](https://optimistic.etherscan.io/address/0x559a14a2219Ae81f9a9f857CF31407de2b07F36c) |
+|          | Polygon   | [`0xe06efA3D9Ee6923240ee1195A16ddd96B5CcE8F7`](https://polygonscan.com/address/0xe06efA3D9Ee6923240ee1195A16ddd96B5CcE8F7) |
+|          | Fantom    | [`0x2bC001fFEB862d843e0a02a7163C7d4828e5FB10`](https://ftmscan.com/address/0x2bC001fFEB862d843e0a02a7163C7d4828e5FB10)     |
+|          | Avalanche | [`0xD1f617fDC0E2e7aF49f7250f163095E76F8e4B32`](https://snowtrace.io/address/0xD1f617fDC0E2e7aF49f7250f163095E76F8e4B32)    |
 | Policy   | Ethereum  | [`0x0cf30dc0d48604A301dF8010cdc028C055336b2E`](https://etherscan.io/address/0x0cf30dc0d48604A301dF8010cdc028C055336b2E)    |
-| DAO      | Optimism | [`0x559a14a2219Ae81f9a9f857CF31407de2b07F36c`](https://optimistic.etherscan.io/address/0x559a14a2219Ae81f9a9f857CF31407de2b07F36c) |    
-|
+|          | Goerli | [`0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7`](https://goerli.etherscan.io/address/0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7) |
+| Executor | Goerli  | [`0x84C0C005cF574D0e5C602EA7b366aE9c707381E0`](https://goerli.etherscan.io/address/0x84C0C005cF574D0e5C602EA7b366aE9c707381E0) |
+| Guardian  | Goerli | [`0x84C0C005cF574D0e5C602EA7b366aE9c707381E0`](https://goerli.etherscan.io/address/0x84C0C005cF574D0e5C602EA7b366aE9c707381E0) |
+| Emergency | Goerli | [`0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7`](https://goerli.etherscan.io/address/0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7) |
+
+
+
+## Flex Loans
+
+| Contract                        | Address                                                                                                                 |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Flex Loan contract (Incur Debt) | [`0xd9d87586774Fb9d036fa95A5991474513Ff6C96E`](https://etherscan.io/address/0xd9d87586774Fb9d036fa95A5991474513Ff6C96E) |
+| Curve Strategy                  | [`0x4B152CCB613Ee248df9bb98195bC505665D6C4b2`](https://etherscan.io/address/0x4B152CCB613Ee248df9bb98195bC505665D6C4b2) |
+| Uniswap Strategy                | [`0x39D1984051759830F0C0Ae979b4aEd776CF481E0`](https://etherscan.io/address/0x39D1984051759830F0C0Ae979b4aEd776CF481E0) |
+| Sushiswap Strategy              | [`0x0692bDcAa767Dc62C420B7893a1045E657771324`](https://etherscan.io/address/0x0692bDcAa767Dc62C420B7893a1045E657771324) |
+| Balancer Strategy               | [`0x48BdC486C9DF31848C62FDc85c5c77d4Be013cDC`](https://etherscan.io/address/0x48BdC486C9DF31848C62FDc85c5c77d4Be013cDC) |

--- a/docs/technical/01_addresses.md
+++ b/docs/technical/01_addresses.md
@@ -4,132 +4,126 @@
 
 ### Kernel
 
-|   Contract   |   Chain   | Address |
-|-----------|-----------------|-----------------|
-|   Kernel  |   Mainnet        | [`0x2286d7f9639e8158FaD1169e76d1FbC38247f54b`](https://etherscan.io/address/0x2286d7f9639e8158FaD1169e76d1FbC38247f54b) |
-|           |   Arbitrum       | [`0xeac3eC0CC130f4826715187805d1B50e861F2DaC`](https://arbiscan.io/address/0xeac3eC0CC130f4826715187805d1B50e861F2DaC) |
-|           |   Goerli       | [`0xDb7cf68154bd422dF5196D90285ceA057786b4c3`](https://goerli.etherscan.io/address/0xDb7cf68154bd422dF5196D90285ceA057786b4c3) |
-
+| Contract | Chain    | Address                                                                                                                        |
+| -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Kernel   | Mainnet  | [`0x2286d7f9639e8158FaD1169e76d1FbC38247f54b`](https://etherscan.io/address/0x2286d7f9639e8158FaD1169e76d1FbC38247f54b)        |
+|          | Arbitrum | [`0xeac3eC0CC130f4826715187805d1B50e861F2DaC`](https://arbiscan.io/address/0xeac3eC0CC130f4826715187805d1B50e861F2DaC)         |
+|          | Goerli   | [`0xDb7cf68154bd422dF5196D90285ceA057786b4c3`](https://goerli.etherscan.io/address/0xDb7cf68154bd422dF5196D90285ceA057786b4c3) |
 
 ### Modules
-| Contract | Chain | Address |
-| -------- | -------- | -------- |
-| TRSRY    | Mainnet | [`0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613`](https://etherscan.io/address/0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613) |
-|          | Goerli  | [`0xD8C59cFe5afbDB83D904E56D379028a2f6A07a2D`](https://goerli.etherscan.io/address/0xD8C59cFe5afbDB83D904E56D379028a2f6A07a2D) |
-| MINTR    | Mainnet  |  [`0xa90bFe53217da78D900749eb6Ef513ee5b6a491e`](https://etherscan.io/address/0xa90bFe53217da78D900749eb6Ef513ee5b6a491e) |
-|          | Arbitrum | [`0x8f6406eDbFA393e327822D4A08BcF15503570D87`](https://arbiscan.io/address/0x8f6406eDbFA393e327822D4A08BcF15503570D87) |
+
+| Contract | Chain    | Address                                                                                                                        |
+| -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| TRSRY    | Mainnet  | [`0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613`](https://etherscan.io/address/0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613)        |
+|          | Goerli   | [`0xD8C59cFe5afbDB83D904E56D379028a2f6A07a2D`](https://goerli.etherscan.io/address/0xD8C59cFe5afbDB83D904E56D379028a2f6A07a2D) |
+| MINTR    | Mainnet  | [`0xa90bFe53217da78D900749eb6Ef513ee5b6a491e`](https://etherscan.io/address/0xa90bFe53217da78D900749eb6Ef513ee5b6a491e)        |
+|          | Arbitrum | [`0x8f6406eDbFA393e327822D4A08BcF15503570D87`](https://arbiscan.io/address/0x8f6406eDbFA393e327822D4A08BcF15503570D87)         |
 |          | Goerli   | [`0xa192fFBF73858831a137DD098a706139Ca96AbD5`](https://goerli.etherscan.io/address/0xa192fFBF73858831a137DD098a706139Ca96AbD5) |
-| PRICE    | Mainnet | [`0xd6C4D723fdadCf0D171eF9A2a3Bfa870675b282f`](https://etherscan.io/address/0xd6C4D723fdadCf0D171eF9A2a3Bfa870675b282f) |
-|          | Goerli  | [`0xD9ace3Be2d80006EF4D90A2D35D861a5C9F98252`](https://goerli.etherscan.io/address/0xD9ace3Be2d80006EF4D90A2D35D861a5C9F98252) |
-| RANGE    | Mainnet | [`0xb212D9584cfc56EFf1117F412Fe0bBdc53673954`](https://etherscan.io/address/0xb212D9584cfc56EFf1117F412Fe0bBdc53673954) |
-|          | Goerli  | [`0x446f06f8Df7d5f627B073c6349b948B95c1f9185`](https://goerli.etherscan.io/address/0x446f06f8Df7d5f627B073c6349b948B95c1f9185) |
-| ROLES    | Mainnet  | [`0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59`](https://etherscan.io/address/0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59) |
-|          | Arbitrum | [`0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6`](https://arbiscan.io/address/0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6) |
+| PRICE    | Mainnet  | [`0xd6C4D723fdadCf0D171eF9A2a3Bfa870675b282f`](https://etherscan.io/address/0xd6C4D723fdadCf0D171eF9A2a3Bfa870675b282f)        |
+|          | Goerli   | [`0xD9ace3Be2d80006EF4D90A2D35D861a5C9F98252`](https://goerli.etherscan.io/address/0xD9ace3Be2d80006EF4D90A2D35D861a5C9F98252) |
+| RANGE    | Mainnet  | [`0xb212D9584cfc56EFf1117F412Fe0bBdc53673954`](https://etherscan.io/address/0xb212D9584cfc56EFf1117F412Fe0bBdc53673954)        |
+|          | Goerli   | [`0x446f06f8Df7d5f627B073c6349b948B95c1f9185`](https://goerli.etherscan.io/address/0x446f06f8Df7d5f627B073c6349b948B95c1f9185) |
+| ROLES    | Mainnet  | [`0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59`](https://etherscan.io/address/0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59)        |
+|          | Arbitrum | [`0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6`](https://arbiscan.io/address/0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6)         |
 |          | Goerli   | [`0xe9a9d80CE3eE32FFf7279dce4c2962eC8098f71B`](https://goerli.etherscan.io/address/0xe9a9d80CE3eE32FFf7279dce4c2962eC8098f71B) |
-| BLREG    | Mainnet | [`0x375E06C694B5E50aF8be8FB03495A612eA3e2275`](https://etherscan.io/address/0x375E06C694B5E50aF8be8FB03495A612eA3e2275) |
-|          | Goerli  | [`0x24963bEA5a156E3dAb8aBA4FCB8a2dBE8c1Aaa14`](https://goerli.etherscan.io/address/0x24963bEA5a156E3dAb8aBA4FCB8a2dBE8c1Aaa14) |
-
-
-
-
-
+| BLREG    | Mainnet  | [`0x375E06C694B5E50aF8be8FB03495A612eA3e2275`](https://etherscan.io/address/0x375E06C694B5E50aF8be8FB03495A612eA3e2275)        |
+|          | Goerli   | [`0x24963bEA5a156E3dAb8aBA4FCB8a2dBE8c1Aaa14`](https://goerli.etherscan.io/address/0x24963bEA5a156E3dAb8aBA4FCB8a2dBE8c1Aaa14) |
 
 ### Policies
-| Contract | Chain | Address |
-| -------- | ----  | ------- |
-| BondCallback       | Mainnet |  [`0xbf2B6E99B0E8D4c96b946c182132f5752eAa55C6`](https://etherscan.io/address/0xbf2B6E99B0E8D4c96b946c182132f5752eAa55C6) |
-|                    | Goerli  | [`0xC1545804Fb804fdC7756e8e40c91B7581b2a2856`](https://goerli.etherscan.io/address/0xC1545804Fb804fdC7756e8e40c91B7581b2a2856) |
-| Operator           | Mainnet | [`0x1Ce568DbB34B2631aCDB5B453c3195EA0070EC65`](https://etherscan.io/address/0x1Ce568DbB34B2631aCDB5B453c3195EA0070EC65) |
-|                    | Goerli  | [`0x61B79d10ebC48166F7495Fce5E0c352B61777460`](https://goerli.etherscan.io/address/0x61B79d10ebC48166F7495Fce5E0c352B61777460) |
-| Heart              | Mainnet | [`0x1652b503E0F1CF38b6246Ed3b91CB3786Bb11656`](https://etherscan.io/address/0x1652b503E0F1CF38b6246Ed3b91CB3786Bb11656) |
-|                    | Goerli  | [`0x384c7AeFB9f7aF276CF717905A696F85E2dD8845`](https://goerli.etherscan.io/address/0x384c7AeFB9f7aF276CF717905A696F85E2dD8845) |
-| PriceConfig        | Mainnet | [`0xf6D5d06A4e8e6904E4360108749C177692F59E90`](https://etherscan.io/address/0xf6D5d06A4e8e6904E4360108749C177692F59E90) |
-|                    | Goerli  | [`0x15915Be9d272B353BA06FA5Ce3918ae7D27F5463`](https://goerli.etherscan.io/address/0x15915Be9d272B353BA06FA5Ce3918ae7D27F5463) |
-| RolesAdmin         | Mainnet  | [`0xb216d714d91eeC4F7120a732c11428857C659eC8`](https://etherscan.io/address/0xb216d714d91eeC4F7120a732c11428857C659eC8) |
-|                    | Arbitrum | [`0x69168c08AcF66f002fd02E1B169f38C022c93b70`](https://arbiscan.io/address/0x69168c08AcF66f002fd02E1B169f38C022c93b70) |
-|                    | Goerli   | [`0x54FfCA586cD1B01E96a5682DF93a55d7Ef91EFF0`](https://goerli.etherscan.io/address/0x54FfCA586cD1B01E96a5682DF93a55d7Ef91EFF0) |
-| TreasuryCustodian  | Mainnet | [`0xC9518AC915e46D707585116451Dc19c164513Ccf`](https://etherscan.io/address/0xC9518AC915e46D707585116451Dc19c164513Ccf) |
-|                    | Goerli  | [`0x3DAE418f8B6382b3d3d0cb9008924BA83D2e0E87`](https://goerli.etherscan.io/address/0x3DAE418f8B6382b3d3d0cb9008924BA83D2e0E87) |
-| Distributor        | Mainnet | [`0x27e606fdb5C922F8213dC588A434BF7583697866`](https://etherscan.io/address/0x27e606fdb5C922F8213dC588A434BF7583697866) |
-|                    | Goerli  | [`0x2716a1451BDE2B011f0D10ad6599e411d54Ec491`](https://goerli.etherscan.io/address/0x2716a1451BDE2B011f0D10ad6599e411d54Ec491) |
-| Emergency          | Mainnet | [`0x9229b0b6FA4A58D67Eb465567DaA2c6A34714A75`](https://etherscan.io/address/0x9229b0b6FA4A58D67Eb465567DaA2c6A34714A75) |
-|                    | Goerli  | [`0x196a59fB453da942f062Be4407D923129c759435`](https://goerli.etherscan.io/address/0x196a59fB453da942f062Be4407D923129c759435) |
-| BondManager        | Mainnet | [`0xf577c77ee3578c7F216327F41B5D7221EaD2B2A3`](https://etherscan.io/address/0xf577c77ee3578c7f216327f41b5d7221ead2b2a3) |
-|                    | Goerli  | [`0x1e5a6834A71770067fcCbAeDDBC86b6d8dFDCb27`](https://goerli.etherscan.io/address/0x1e5a6834A71770067fcCbAeDDBC86b6d8dFDCb27) |
-| BLVaultManagerLido | Mainnet | [`0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23`](https://etherscan.io/address/0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23) |
-|                    | Goerli  | [`0x5c9352d333F4D9EA1FDbF374d8D392e1843D0E34`](https://goerli.etherscan.io/address/0x5c9352d333F4D9EA1FDbF374d8D392e1843D0E34) |
-| CrossChainBridge   | Mainnet  | [`0x45e563c39cddba8699a90078f42353a57509543a`](https://etherscan.io/address/0x45e563c39cddba8699a90078f42353a57509543a) |
-|                    | Arbitrum | [`0x20B3834091f038Ce04D8686FAC99CA44A0FB285c`](https://arbiscan.io/address/0x20B3834091f038Ce04D8686FAC99CA44A0FB285c) | 
-| Faucet (Testnet only) | Goerli | [`0xA247156a39169c0FAFf979F57361CC734e82e3d0`](https://goerli.etherscan.io/address/0xA247156a39169c0FAFf979F57361CC734e82e3d0) |
 
-
+| Contract              | Chain    | Address                                                                                                                        |
+| --------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| BondCallback          | Mainnet  | [`0xbf2B6E99B0E8D4c96b946c182132f5752eAa55C6`](https://etherscan.io/address/0xbf2B6E99B0E8D4c96b946c182132f5752eAa55C6)        |
+|                       | Goerli   | [`0xC1545804Fb804fdC7756e8e40c91B7581b2a2856`](https://goerli.etherscan.io/address/0xC1545804Fb804fdC7756e8e40c91B7581b2a2856) |
+| Operator              | Mainnet  | [`0x1Ce568DbB34B2631aCDB5B453c3195EA0070EC65`](https://etherscan.io/address/0x1Ce568DbB34B2631aCDB5B453c3195EA0070EC65)        |
+|                       | Goerli   | [`0x61B79d10ebC48166F7495Fce5E0c352B61777460`](https://goerli.etherscan.io/address/0x61B79d10ebC48166F7495Fce5E0c352B61777460) |
+| Heart                 | Mainnet  | [`0x1652b503E0F1CF38b6246Ed3b91CB3786Bb11656`](https://etherscan.io/address/0x1652b503E0F1CF38b6246Ed3b91CB3786Bb11656)        |
+|                       | Goerli   | [`0x384c7AeFB9f7aF276CF717905A696F85E2dD8845`](https://goerli.etherscan.io/address/0x384c7AeFB9f7aF276CF717905A696F85E2dD8845) |
+| PriceConfig           | Mainnet  | [`0xf6D5d06A4e8e6904E4360108749C177692F59E90`](https://etherscan.io/address/0xf6D5d06A4e8e6904E4360108749C177692F59E90)        |
+|                       | Goerli   | [`0x15915Be9d272B353BA06FA5Ce3918ae7D27F5463`](https://goerli.etherscan.io/address/0x15915Be9d272B353BA06FA5Ce3918ae7D27F5463) |
+| RolesAdmin            | Mainnet  | [`0xb216d714d91eeC4F7120a732c11428857C659eC8`](https://etherscan.io/address/0xb216d714d91eeC4F7120a732c11428857C659eC8)        |
+|                       | Arbitrum | [`0x69168c08AcF66f002fd02E1B169f38C022c93b70`](https://arbiscan.io/address/0x69168c08AcF66f002fd02E1B169f38C022c93b70)         |
+|                       | Goerli   | [`0x54FfCA586cD1B01E96a5682DF93a55d7Ef91EFF0`](https://goerli.etherscan.io/address/0x54FfCA586cD1B01E96a5682DF93a55d7Ef91EFF0) |
+| TreasuryCustodian     | Mainnet  | [`0xC9518AC915e46D707585116451Dc19c164513Ccf`](https://etherscan.io/address/0xC9518AC915e46D707585116451Dc19c164513Ccf)        |
+|                       | Goerli   | [`0x3DAE418f8B6382b3d3d0cb9008924BA83D2e0E87`](https://goerli.etherscan.io/address/0x3DAE418f8B6382b3d3d0cb9008924BA83D2e0E87) |
+| Distributor           | Mainnet  | [`0x27e606fdb5C922F8213dC588A434BF7583697866`](https://etherscan.io/address/0x27e606fdb5C922F8213dC588A434BF7583697866)        |
+|                       | Goerli   | [`0x2716a1451BDE2B011f0D10ad6599e411d54Ec491`](https://goerli.etherscan.io/address/0x2716a1451BDE2B011f0D10ad6599e411d54Ec491) |
+| Emergency             | Mainnet  | [`0x9229b0b6FA4A58D67Eb465567DaA2c6A34714A75`](https://etherscan.io/address/0x9229b0b6FA4A58D67Eb465567DaA2c6A34714A75)        |
+|                       | Goerli   | [`0x196a59fB453da942f062Be4407D923129c759435`](https://goerli.etherscan.io/address/0x196a59fB453da942f062Be4407D923129c759435) |
+| BondManager           | Mainnet  | [`0xf577c77ee3578c7F216327F41B5D7221EaD2B2A3`](https://etherscan.io/address/0xf577c77ee3578c7f216327f41b5d7221ead2b2a3)        |
+|                       | Goerli   | [`0x1e5a6834A71770067fcCbAeDDBC86b6d8dFDCb27`](https://goerli.etherscan.io/address/0x1e5a6834A71770067fcCbAeDDBC86b6d8dFDCb27) |
+| BLVaultManagerLido    | Mainnet  | [`0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23`](https://etherscan.io/address/0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23)        |
+|                       | Goerli   | [`0x5c9352d333F4D9EA1FDbF374d8D392e1843D0E34`](https://goerli.etherscan.io/address/0x5c9352d333F4D9EA1FDbF374d8D392e1843D0E34) |
+| CrossChainBridge      | Mainnet  | [`0x45e563c39cddba8699a90078f42353a57509543a`](https://etherscan.io/address/0x45e563c39cddba8699a90078f42353a57509543a)        |
+|                       | Arbitrum | [`0x20B3834091f038Ce04D8686FAC99CA44A0FB285c`](https://arbiscan.io/address/0x20B3834091f038Ce04D8686FAC99CA44A0FB285c)         |
+| Faucet (Testnet only) | Goerli   | [`0xA247156a39169c0FAFf979F57361CC734e82e3d0`](https://goerli.etherscan.io/address/0xA247156a39169c0FAFf979F57361CC734e82e3d0) |
 
 ### Dependencies
-| Contract    | Chain | Address |
-| ----------- | ----- | ------- |
-| BondTeller | Mainnet | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
-|            | Goerli | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://goerli.etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
 
+| Contract   | Chain   | Address                                                                                                                        |
+| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| BondTeller | Mainnet | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6)        |
+|            | Goerli  | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://goerli.etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
 
 ### Legacy Contracts
-| Contract    | Chain | Address |
-| ----------- | ----- | ------- |
-| OHM V2      | Mainnet | [`0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5`](https://etherscan.io/address/0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5) |
-|             | Arbitrum  | [`0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028`](https://arbiscan.io/token/0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028)             |
-|             | Goerli   | [`0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b`](https://goerli.etherscan.io/address/0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b) |
-| sOHM V2     | Mainnet | [`0x04906695D6D12CF5459975d7C3C03356E4Ccd460`](https://etherscan.io/address/0x04906695D6D12CF5459975d7C3C03356E4Ccd460) |
-|             | Goerli  | [`0x4EFe119F4949319f2Acb12efD615a7B63896482B`](https://goerli.etherscan.io/address/0x4EFe119F4949319f2Acb12efD615a7B63896482B) |
-| gOHM | Mainnet | [`0x0ab87046fBb341D058F17CBC4c1133F25a20a52f`](https://etherscan.io/address/0x0ab87046fBb341D058F17CBC4c1133F25a20a52f) |
-|      | Arbitrum  | [`0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1`](https://arbiscan.io/token/0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1)             |
-|      | Avalanche | [`0x321e7092a180bb43555132ec53aaa65a5bf84251`](https://snowtrace.io/token/0x321e7092a180bb43555132ec53aaa65a5bf84251)            |
-|      | Polygon   | [`0xd8cA34fd379d9ca3C6Ee3b3905678320F5b45195`](https://polygonscan.com/token/0xd8cA34fd379d9ca3C6Ee3b3905678320F5b45195)         |
-|      | Fantom    | [`0x91fa20244fb509e8289ca630e5db3e9166233fdc`](https://ftmscan.com/token/0x91fa20244fb509e8289ca630e5db3e9166233fdc)             |
-|      | Optimism  | [`0x0b5740c6b4a97f90eF2F0220651Cca420B868FfB`](https://optimistic.etherscan.io/token/0x0b5740c6b4a97f90eF2F0220651Cca420B868FfB) |
-|      | Boba      | [`0xd22C0a4Af486C7FA08e282E9eB5f30F9AaA62C95`](https://bobascan.com/token/0xd22C0a4Af486C7FA08e282E9eB5f30F9AaA62C95)            |
-|      | Goerli  | [`0xC1863141dc1861122d5410fB5973951c82871d98`](https://goerli.etherscan.io/address/0xC1863141dc1861122d5410fB5973951c82871d98) |
-| Staking | Mainnet | [`0xB63cac384247597756545b500253ff8E607a8020`](https://etherscan.io/address/0xB63cac384247597756545b500253ff8E607a8020) |
-|         | Goerli  | [`0x7263372b9ff6E619d8774aEB046cE313677E2Ec7`](https://goerli.etherscan.io/address/0x7263372b9ff6E619d8774aEB046cE313677E2Ec7) |
-| Treasury V2 | Mainnet | [`0x9A315BdF513367C0377FB36545857d12e85813Ef`](https://etherscan.io/address/0x9A315BdF513367C0377FB36545857d12e85813Ef) |
-|             | Goerli  | [`0xB3e1dF7951a62fFb5eF7D3b1C9D80CF09325580A`](https://goerli.etherscan.io/address/0xB3e1dF7951a62fFb5eF7D3b1C9D80CF09325580A) |
-| TreasuryExtender | Mainnet | [`0xb32Ad041f23eAfd682F57fCe31d3eA4fd92D17af`](https://etherscan.io/address/0xb32Ad041f23eAfd682F57fCe31d3eA4fd92D17af) |
-| Distributor | Mainnet | [`0xeeeb97A127a342656191E0313DF33D58D06B2E05`](https://etherscan.io/address/0xeeeb97A127a342656191E0313DF33D58D06B2E05) |
-|             | Goerli  | [`0x2b954551307FB929DF8BB96657DB69fB4d72617c`](https://goerli.etherscan.io/address/0x2b954551307FB929DF8BB96657DB69fB4d72617c) |
-| BondDepositoryV2 | Mainnet | [`0x9025046c6fb25Fb39e720d97a8FD881ED69a1Ef6`](https://etherscan.io/address/0x9025046c6fb25Fb39e720d97a8FD881ED69a1Ef6) |
-|                  | Goerli  | [`0xAda3336fcD233Ff0Eb39BeA0b1a7784E43aD4B00`](https://goerli.etherscan.io/address/0xAda3336fcD233Ff0Eb39BeA0b1a7784E43aD4B00) |
-| Authority | Mainnet | [`0x1c21F8EA7e39E2BA00BC12d2968D63F4acb38b7A`](https://etherscan.io/address/0x1c21F8EA7e39E2BA00BC12d2968D63F4acb38b7A) |
-| YieldDirector | Mainnet | [`0x2604170762A1dD22BB4F96C963043Cd4FC358f18`](https://etherscan.io/address/0x2604170762A1dD22BB4F96C963043Cd4FC358f18) |
-|               | Goerli  | [`0x6982CcD55F95A7469746C123f73D54377f382454`](https://goerli.etherscan.io/address/0x6982CcD55F95A7469746C123f73D54377f382454) |
-| OP Market Creator (for inverse bonds) (old) | Mainnet | [`0xb1fA0Ac44d399b778B14af0AAF4bCF8af3437ad1`](https://etherscan.io/address/0xb1fA0Ac44d399b778B14af0AAF4bCF8af3437ad1) |
-| | Goerli | [`0x0C9D01FbD07cC2fD3e09bD953bb65698351AF05D`](https://goerli.etherscan.io/address/0x0C9D01FbD07cC2fD3e09bD953bb65698351AF05D) |
-| Authority | Arbitrum | [`0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e`](https://arbiscan.io/address/0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e) |
-|           | Goerli   | [`0x4A8c9502A34962a2C6d73c5D181dAaeF3dcDc88D`](https://goerli.etherscan.io/address/0x4A8c9502A34962a2C6d73c5D181dAaeF3dcDc88D) |
-| DAI Token | Goerli   | [`0x41e38e70a36150D08A8c97aEC194321b5eB545A5`](https://goerli.etherscan.io/address/0x41e38e70a36150D08A8c97aEC194321b5eB545A5) |
-| OHM-DAI Balancer LP Pool | Goerli | [`0xd8833594420dB3D6589c1098dbDd073f52419Dba`](https://goerli.etherscan.io/address/0xd8833594420dB3D6589c1098dbDd073f52419Dba) |
-| WETH Token (for keeper rewards) | Goerli | [`0x0Bb7509324cE409F7bbC4b701f932eAca9736AB7`](https://goerli.etherscan.io/address/0x0Bb7509324cE409F7bbC4b701f932eAca9736AB7) |
-| Mock OHM/ETH Price Feed         | Goerli | [`0x022710a589C9796dce59A0C52cA4E36f0a5e991A`](https://goerli.etherscan.io/address/0x022710a589C9796dce59A0C52cA4E36f0a5e991A) |
-| Mock DAI/ETH Price Feed         | Goerli | [`0xdC8E4eD326cFb730a759312B6b1727C6Ef9ca233`](https://goerli.etherscan.io/address/0xdC8E4eD326cFb730a759312B6b1727C6Ef9ca233) |
-| Bond Auctioneer                 | Goerli | [`0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222`](https://goerli.etherscan.io/address/0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222) |
-| Bond Aggregator                 | Goerli | [`0x007A66A2a13415DB3613C1a4dd1C942A285902d1`](https://goerli.etherscan.io/address/0x007A66A2a13415DB3613C1a4dd1C942A285902d1) |
+
+| Contract                                    | Chain     | Address                                                                                                                          |
+| ------------------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| OHM V2                                      | Mainnet   | [`0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5`](https://etherscan.io/address/0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5)          |
+|                                             | Arbitrum  | [`0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028`](https://arbiscan.io/token/0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028)             |
+|                                             | Goerli    | [`0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b`](https://goerli.etherscan.io/address/0x0595328847AF962F951a4f8F8eE9A3Bf261e4f6b)   |
+| sOHM V2                                     | Mainnet   | [`0x04906695D6D12CF5459975d7C3C03356E4Ccd460`](https://etherscan.io/address/0x04906695D6D12CF5459975d7C3C03356E4Ccd460)          |
+|                                             | Goerli    | [`0x4EFe119F4949319f2Acb12efD615a7B63896482B`](https://goerli.etherscan.io/address/0x4EFe119F4949319f2Acb12efD615a7B63896482B)   |
+| gOHM                                        | Mainnet   | [`0x0ab87046fBb341D058F17CBC4c1133F25a20a52f`](https://etherscan.io/address/0x0ab87046fBb341D058F17CBC4c1133F25a20a52f)          |
+|                                             | Arbitrum  | [`0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1`](https://arbiscan.io/token/0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1)             |
+|                                             | Avalanche | [`0x321e7092a180bb43555132ec53aaa65a5bf84251`](https://snowtrace.io/token/0x321e7092a180bb43555132ec53aaa65a5bf84251)            |
+|                                             | Polygon   | [`0xd8cA34fd379d9ca3C6Ee3b3905678320F5b45195`](https://polygonscan.com/token/0xd8cA34fd379d9ca3C6Ee3b3905678320F5b45195)         |
+|                                             | Fantom    | [`0x91fa20244fb509e8289ca630e5db3e9166233fdc`](https://ftmscan.com/token/0x91fa20244fb509e8289ca630e5db3e9166233fdc)             |
+|                                             | Optimism  | [`0x0b5740c6b4a97f90eF2F0220651Cca420B868FfB`](https://optimistic.etherscan.io/token/0x0b5740c6b4a97f90eF2F0220651Cca420B868FfB) |
+|                                             | Boba      | [`0xd22C0a4Af486C7FA08e282E9eB5f30F9AaA62C95`](https://bobascan.com/token/0xd22C0a4Af486C7FA08e282E9eB5f30F9AaA62C95)            |
+|                                             | Goerli    | [`0xC1863141dc1861122d5410fB5973951c82871d98`](https://goerli.etherscan.io/address/0xC1863141dc1861122d5410fB5973951c82871d98)   |
+| Staking                                     | Mainnet   | [`0xB63cac384247597756545b500253ff8E607a8020`](https://etherscan.io/address/0xB63cac384247597756545b500253ff8E607a8020)          |
+|                                             | Goerli    | [`0x7263372b9ff6E619d8774aEB046cE313677E2Ec7`](https://goerli.etherscan.io/address/0x7263372b9ff6E619d8774aEB046cE313677E2Ec7)   |
+| Treasury V2                                 | Mainnet   | [`0x9A315BdF513367C0377FB36545857d12e85813Ef`](https://etherscan.io/address/0x9A315BdF513367C0377FB36545857d12e85813Ef)          |
+|                                             | Goerli    | [`0xB3e1dF7951a62fFb5eF7D3b1C9D80CF09325580A`](https://goerli.etherscan.io/address/0xB3e1dF7951a62fFb5eF7D3b1C9D80CF09325580A)   |
+| TreasuryExtender                            | Mainnet   | [`0xb32Ad041f23eAfd682F57fCe31d3eA4fd92D17af`](https://etherscan.io/address/0xb32Ad041f23eAfd682F57fCe31d3eA4fd92D17af)          |
+| Distributor                                 | Mainnet   | [`0xeeeb97A127a342656191E0313DF33D58D06B2E05`](https://etherscan.io/address/0xeeeb97A127a342656191E0313DF33D58D06B2E05)          |
+|                                             | Goerli    | [`0x2b954551307FB929DF8BB96657DB69fB4d72617c`](https://goerli.etherscan.io/address/0x2b954551307FB929DF8BB96657DB69fB4d72617c)   |
+| BondDepositoryV2                            | Mainnet   | [`0x9025046c6fb25Fb39e720d97a8FD881ED69a1Ef6`](https://etherscan.io/address/0x9025046c6fb25Fb39e720d97a8FD881ED69a1Ef6)          |
+|                                             | Goerli    | [`0xAda3336fcD233Ff0Eb39BeA0b1a7784E43aD4B00`](https://goerli.etherscan.io/address/0xAda3336fcD233Ff0Eb39BeA0b1a7784E43aD4B00)   |
+| Authority                                   | Mainnet   | [`0x1c21F8EA7e39E2BA00BC12d2968D63F4acb38b7A`](https://etherscan.io/address/0x1c21F8EA7e39E2BA00BC12d2968D63F4acb38b7A)          |
+| YieldDirector                               | Mainnet   | [`0x2604170762A1dD22BB4F96C963043Cd4FC358f18`](https://etherscan.io/address/0x2604170762A1dD22BB4F96C963043Cd4FC358f18)          |
+|                                             | Goerli    | [`0x6982CcD55F95A7469746C123f73D54377f382454`](https://goerli.etherscan.io/address/0x6982CcD55F95A7469746C123f73D54377f382454)   |
+| OP Market Creator (for inverse bonds) (old) | Mainnet   | [`0xb1fA0Ac44d399b778B14af0AAF4bCF8af3437ad1`](https://etherscan.io/address/0xb1fA0Ac44d399b778B14af0AAF4bCF8af3437ad1)          |
+|                                             | Goerli    | [`0x0C9D01FbD07cC2fD3e09bD953bb65698351AF05D`](https://goerli.etherscan.io/address/0x0C9D01FbD07cC2fD3e09bD953bb65698351AF05D)   |
+| Authority                                   | Arbitrum  | [`0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e`](https://arbiscan.io/address/0x78f84998c73655ac2Da0Aa1e1270F6Cb985a343e)           |
+|                                             | Goerli    | [`0x4A8c9502A34962a2C6d73c5D181dAaeF3dcDc88D`](https://goerli.etherscan.io/address/0x4A8c9502A34962a2C6d73c5D181dAaeF3dcDc88D)   |
+| DAI Token                                   | Goerli    | [`0x41e38e70a36150D08A8c97aEC194321b5eB545A5`](https://goerli.etherscan.io/address/0x41e38e70a36150D08A8c97aEC194321b5eB545A5)   |
+| OHM-DAI Balancer LP Pool                    | Goerli    | [`0xd8833594420dB3D6589c1098dbDd073f52419Dba`](https://goerli.etherscan.io/address/0xd8833594420dB3D6589c1098dbDd073f52419Dba)   |
+| WETH Token (for keeper rewards)             | Goerli    | [`0x0Bb7509324cE409F7bbC4b701f932eAca9736AB7`](https://goerli.etherscan.io/address/0x0Bb7509324cE409F7bbC4b701f932eAca9736AB7)   |
+| Mock OHM/ETH Price Feed                     | Goerli    | [`0x022710a589C9796dce59A0C52cA4E36f0a5e991A`](https://goerli.etherscan.io/address/0x022710a589C9796dce59A0C52cA4E36f0a5e991A)   |
+| Mock DAI/ETH Price Feed                     | Goerli    | [`0xdC8E4eD326cFb730a759312B6b1727C6Ef9ca233`](https://goerli.etherscan.io/address/0xdC8E4eD326cFb730a759312B6b1727C6Ef9ca233)   |
+| Bond Auctioneer                             | Goerli    | [`0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222`](https://goerli.etherscan.io/address/0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222)   |
+| Bond Aggregator                             | Goerli    | [`0x007A66A2a13415DB3613C1a4dd1C942A285902d1`](https://goerli.etherscan.io/address/0x007A66A2a13415DB3613C1a4dd1C942A285902d1)   |
 
 ## Multisigs
 
-| Contract | Chain     | Address                                                                                                                    |
-| -------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
-| DAO      | Ethereum  | [`0x245cc372C84B3645Bf0Ffe6538620B04a217988B`](https://etherscan.io/address/0x245cc372C84B3645Bf0Ffe6538620B04a217988B)    |
-|          | Arbitrum  | [`0x012BBf0481b97170577745D2167ee14f63E2aD4C`](https://arbiscan.io/address/0x012BBf0481b97170577745D2167ee14f63E2aD4C)     |
-|          | Optimism | [`0x559a14a2219Ae81f9a9f857CF31407de2b07F36c`](https://optimistic.etherscan.io/address/0x559a14a2219Ae81f9a9f857CF31407de2b07F36c) |
-|          | Polygon   | [`0xe06efA3D9Ee6923240ee1195A16ddd96B5CcE8F7`](https://polygonscan.com/address/0xe06efA3D9Ee6923240ee1195A16ddd96B5CcE8F7) |
-|          | Fantom    | [`0x2bC001fFEB862d843e0a02a7163C7d4828e5FB10`](https://ftmscan.com/address/0x2bC001fFEB862d843e0a02a7163C7d4828e5FB10)     |
-|          | Avalanche | [`0xD1f617fDC0E2e7aF49f7250f163095E76F8e4B32`](https://snowtrace.io/address/0xD1f617fDC0E2e7aF49f7250f163095E76F8e4B32)    |
-| Policy   | Ethereum  | [`0x0cf30dc0d48604A301dF8010cdc028C055336b2E`](https://etherscan.io/address/0x0cf30dc0d48604A301dF8010cdc028C055336b2E)    |
-|          | Goerli | [`0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7`](https://goerli.etherscan.io/address/0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7) |
-| Executor | Goerli  | [`0x84C0C005cF574D0e5C602EA7b366aE9c707381E0`](https://goerli.etherscan.io/address/0x84C0C005cF574D0e5C602EA7b366aE9c707381E0) |
-| Guardian  | Goerli | [`0x84C0C005cF574D0e5C602EA7b366aE9c707381E0`](https://goerli.etherscan.io/address/0x84C0C005cF574D0e5C602EA7b366aE9c707381E0) |
-| Emergency | Goerli | [`0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7`](https://goerli.etherscan.io/address/0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7) |
-
-
+| Contract  | Chain     | Address                                                                                                                            |
+| --------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| DAO       | Ethereum  | [`0x245cc372C84B3645Bf0Ffe6538620B04a217988B`](https://etherscan.io/address/0x245cc372C84B3645Bf0Ffe6538620B04a217988B)            |
+|           | Arbitrum  | [`0x012BBf0481b97170577745D2167ee14f63E2aD4C`](https://arbiscan.io/address/0x012BBf0481b97170577745D2167ee14f63E2aD4C)             |
+|           | Optimism  | [`0x559a14a2219Ae81f9a9f857CF31407de2b07F36c`](https://optimistic.etherscan.io/address/0x559a14a2219Ae81f9a9f857CF31407de2b07F36c) |
+|           | Polygon   | [`0xe06efA3D9Ee6923240ee1195A16ddd96B5CcE8F7`](https://polygonscan.com/address/0xe06efA3D9Ee6923240ee1195A16ddd96B5CcE8F7)         |
+|           | Fantom    | [`0x2bC001fFEB862d843e0a02a7163C7d4828e5FB10`](https://ftmscan.com/address/0x2bC001fFEB862d843e0a02a7163C7d4828e5FB10)             |
+|           | Avalanche | [`0xD1f617fDC0E2e7aF49f7250f163095E76F8e4B32`](https://snowtrace.io/address/0xD1f617fDC0E2e7aF49f7250f163095E76F8e4B32)            |
+| Policy    | Ethereum  | [`0x0cf30dc0d48604A301dF8010cdc028C055336b2E`](https://etherscan.io/address/0x0cf30dc0d48604A301dF8010cdc028C055336b2E)            |
+|           | Goerli    | [`0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7`](https://goerli.etherscan.io/address/0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7)     |
+| Executor  | Goerli    | [`0x84C0C005cF574D0e5C602EA7b366aE9c707381E0`](https://goerli.etherscan.io/address/0x84C0C005cF574D0e5C602EA7b366aE9c707381E0)     |
+| Guardian  | Goerli    | [`0x84C0C005cF574D0e5C602EA7b366aE9c707381E0`](https://goerli.etherscan.io/address/0x84C0C005cF574D0e5C602EA7b366aE9c707381E0)     |
+| Emergency | Goerli    | [`0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7`](https://goerli.etherscan.io/address/0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7)     |
 
 ## Allocators
+
 | Contract         | Address                                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | AaveAllocatorV2  | [`0x0D33c811D0fcC711BcB388DFB3a152DE445bE66F`](https://etherscan.io/address/0x0D33c811D0fcC711BcB388DFB3a152DE445bE66F) |
@@ -141,8 +135,6 @@
 | FxsAllocatorV2   | [`0x0f953D861347414698F34B75dbFd6e7dF1A73493`](https://etherscan.io/address/0x0f953D861347414698F34B75dbFd6e7dF1A73493) |
 | LUSDAllocatorV2  | [`0x97b3Ef4C558Ec456D59Cb95c65BFB79046E31fCA`](https://etherscan.io/address/0x97b3Ef4C558Ec456D59Cb95c65BFB79046E31fCA) |
 | OlympusCvxHolder | [`0xdFC95aaf0a107DaAe2b350458DED4b7906E7f728`](https://etherscan.io/address/0xdFC95aaf0a107DaAe2b350458DED4b7906E7f728) |
-
-
 
 ## Flex Loans
 

--- a/docs/technical/01_addresses.md
+++ b/docs/technical/01_addresses.md
@@ -111,21 +111,6 @@
 | Bond Auctioneer                 | Goerli | [`0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222`](https://goerli.etherscan.io/address/0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222) |
 | Bond Aggregator                 | Goerli | [`0x007A66A2a13415DB3613C1a4dd1C942A285902d1`](https://goerli.etherscan.io/address/0x007A66A2a13415DB3613C1a4dd1C942A285902d1) |
 
-
-## Allocators
-
-| Contract         | Address                                                                                                                 |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| AaveAllocatorV2  | [`0x0D33c811D0fcC711BcB388DFB3a152DE445bE66F`](https://etherscan.io/address/0x0D33c811D0fcC711BcB388DFB3a152DE445bE66F) |
-| AuraAllocatorV2  | [`0x8CaF91A6bb38D55fB530dEc0faB535FA78d98FaD`](https://etherscan.io/address/0x8CaF91A6bb38D55fB530dEc0faB535FA78d98FaD) |
-| BtrflyAllocator  | [`0xC8431fEb345B46c30A4576c1b5faF080fdc54e2f`](https://etherscan.io/address/0xC8431fEb345B46c30A4576c1b5faF080fdc54e2f) |
-| CVXAllocatorV2   | [`0x2d643Df5De4e9Ba063760d475BEAa62821c71681`](https://etherscan.io/address/0x2d643Df5De4e9Ba063760d475BEAa62821c71681) |
-| DSRAllocator     | [`0x0EA26319836fF05B8C5C5afD83b8aB17dd46d063`](https://etherscan.io/address/0x0EA26319836fF05B8C5C5afD83b8aB17dd46d063) |
-| FXS Allocator V1 | [`0xde7b85f52577B113181921A7aa8Fc0C22e309475`](https://etherscan.io/address/0xde7b85f52577B113181921A7aa8Fc0C22e309475) |
-| FxsAllocatorV2   | [`0x0f953D861347414698F34B75dbFd6e7dF1A73493`](https://etherscan.io/address/0x0f953D861347414698F34B75dbFd6e7dF1A73493) |
-| LUSDAllocatorV2  | [`0x97b3Ef4C558Ec456D59Cb95c65BFB79046E31fCA`](https://etherscan.io/address/0x97b3Ef4C558Ec456D59Cb95c65BFB79046E31fCA) |
-| OlympusCvxHolder | [`0xdFC95aaf0a107DaAe2b350458DED4b7906E7f728`](https://etherscan.io/address/0xdFC95aaf0a107DaAe2b350458DED4b7906E7f728) |
-
 ## Multisigs
 
 | Contract | Chain     | Address                                                                                                                    |
@@ -141,6 +126,21 @@
 | Executor | Goerli  | [`0x84C0C005cF574D0e5C602EA7b366aE9c707381E0`](https://goerli.etherscan.io/address/0x84C0C005cF574D0e5C602EA7b366aE9c707381E0) |
 | Guardian  | Goerli | [`0x84C0C005cF574D0e5C602EA7b366aE9c707381E0`](https://goerli.etherscan.io/address/0x84C0C005cF574D0e5C602EA7b366aE9c707381E0) |
 | Emergency | Goerli | [`0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7`](https://goerli.etherscan.io/address/0x3dC18017cf8d8F4219dB7A8B93315fEC2d15B8a7) |
+
+
+
+## Allocators
+| Contract         | Address                                                                                                                 |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| AaveAllocatorV2  | [`0x0D33c811D0fcC711BcB388DFB3a152DE445bE66F`](https://etherscan.io/address/0x0D33c811D0fcC711BcB388DFB3a152DE445bE66F) |
+| AuraAllocatorV2  | [`0x8CaF91A6bb38D55fB530dEc0faB535FA78d98FaD`](https://etherscan.io/address/0x8CaF91A6bb38D55fB530dEc0faB535FA78d98FaD) |
+| BtrflyAllocator  | [`0xC8431fEb345B46c30A4576c1b5faF080fdc54e2f`](https://etherscan.io/address/0xC8431fEb345B46c30A4576c1b5faF080fdc54e2f) |
+| CVXAllocatorV2   | [`0x2d643Df5De4e9Ba063760d475BEAa62821c71681`](https://etherscan.io/address/0x2d643Df5De4e9Ba063760d475BEAa62821c71681) |
+| DSRAllocator     | [`0x0EA26319836fF05B8C5C5afD83b8aB17dd46d063`](https://etherscan.io/address/0x0EA26319836fF05B8C5C5afD83b8aB17dd46d063) |
+| FXS Allocator V1 | [`0xde7b85f52577B113181921A7aa8Fc0C22e309475`](https://etherscan.io/address/0xde7b85f52577B113181921A7aa8Fc0C22e309475) |
+| FxsAllocatorV2   | [`0x0f953D861347414698F34B75dbFd6e7dF1A73493`](https://etherscan.io/address/0x0f953D861347414698F34B75dbFd6e7dF1A73493) |
+| LUSDAllocatorV2  | [`0x97b3Ef4C558Ec456D59Cb95c65BFB79046E31fCA`](https://etherscan.io/address/0x97b3Ef4C558Ec456D59Cb95c65BFB79046E31fCA) |
+| OlympusCvxHolder | [`0xdFC95aaf0a107DaAe2b350458DED4b7906E7f728`](https://etherscan.io/address/0xdFC95aaf0a107DaAe2b350458DED4b7906E7f728) |
 
 
 

--- a/docs/technical/01_addresses.md
+++ b/docs/technical/01_addresses.md
@@ -9,18 +9,21 @@
 |   Kernel  |   Mainnet        | [`0x2286d7f9639e8158FaD1169e76d1FbC38247f54b`](https://etherscan.io/address/0x2286d7f9639e8158FaD1169e76d1FbC38247f54b) |
 |           |   Arbitrum       | [`0xeac3eC0CC130f4826715187805d1B50e861F2DaC`](https://arbiscan.io/address/0xeac3eC0CC130f4826715187805d1B50e861F2DaC) |
 
-#### Modules
+### Modules
 
-| Contract | Address                                                                                                                 |
-| -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| TRSRY    | [`0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613`](https://etherscan.io/address/0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613) |
-| MINTR    | [`0xa90bFe53217da78D900749eb6Ef513ee5b6a491e`](https://etherscan.io/address/0xa90bFe53217da78D900749eb6Ef513ee5b6a491e) |
-| PRICE    | [`0xd6C4D723fdadCf0D171eF9A2a3Bfa870675b282f`](https://etherscan.io/address/0xd6C4D723fdadCf0D171eF9A2a3Bfa870675b282f) |
-| RANGE    | [`0xb212D9584cfc56EFf1117F412Fe0bBdc53673954`](https://etherscan.io/address/0xb212D9584cfc56EFf1117F412Fe0bBdc53673954) |
-| ROLES    | [`0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59`](https://etherscan.io/address/0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59) |
-| BLREG    | [`0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59`](https://etherscan.io/address/0x375E06C694B5E50aF8be8FB03495A612eA3e2275) |
+| Contract | Chain | Address |
+| -------- | -------- | -------- |
+| TRSRY    | Mainnet | [`0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613`](https://etherscan.io/address/0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613) |
+| MINTR    | Mainnet  |  [`0xa90bFe53217da78D900749eb6Ef513ee5b6a491e`](https://etherscan.io/address/0xa90bFe53217da78D900749eb6Ef513ee5b6a491e) |
+|          | Arbitrum | [`0x8f6406eDbFA393e327822D4A08BcF15503570D87`](https://arbiscan.io/address/0x8f6406eDbFA393e327822D4A08BcF15503570D87) |
+| PRICE    | Mainnet | [`0xd6C4D723fdadCf0D171eF9A2a3Bfa870675b282f`](https://etherscan.io/address/0xd6C4D723fdadCf0D171eF9A2a3Bfa870675b282f) |
+| RANGE    | Mainnet| [`0xb212D9584cfc56EFf1117F412Fe0bBdc53673954`](https://etherscan.io/address/0xb212D9584cfc56EFf1117F412Fe0bBdc53673954) |
+| ROLES    | Mainnet  | [`0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59`](https://etherscan.io/address/0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59) |
+|          | Arbitrum | [`0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6`](https://arbiscan.io/address/0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6) |
+| BLREG    | Mainnet | [`0x6CAfd730Dc199Df73C16420C4fCAb18E3afbfA59`](https://etherscan.io/address/0x375E06C694B5E50aF8be8FB03495A612eA3e2275) |
 
-#### Policies
+
+### Policies
 
 | Contract           | Address                                                                                                                 |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
@@ -43,13 +46,6 @@
 | Bond Teller | [`0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6`](https://etherscan.io/address/0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6) |
 
 ### Arbitrum
-
-#### Modules
-
-| Contract | Address                                                                                                                |
-| -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| MINTR    | [`0x8f6406eDbFA393e327822D4A08BcF15503570D87`](https://arbiscan.io/address/0x8f6406eDbFA393e327822D4A08BcF15503570D87) |
-| ROLES    | [`0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6`](https://arbiscan.io/address/0xFF5F09D5efE13A9a424F30EC2e1af89D867834d6) |
 
 #### Policies
 

--- a/docs/technical/01_addresses.md
+++ b/docs/technical/01_addresses.md
@@ -25,19 +25,21 @@
 
 ### Policies
 
-| Contract           | Address                                                                                                                 |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| BondCallback       | [`0xbf2B6E99B0E8D4c96b946c182132f5752eAa55C6`](https://etherscan.io/address/0xbf2B6E99B0E8D4c96b946c182132f5752eAa55C6) |
-| Operator           | [`0x1Ce568DbB34B2631aCDB5B453c3195EA0070EC65`](https://etherscan.io/address/0x1Ce568DbB34B2631aCDB5B453c3195EA0070EC65) |
-| Heart              | [`0x1652b503E0F1CF38b6246Ed3b91CB3786Bb11656`](https://etherscan.io/address/0x1652b503E0F1CF38b6246Ed3b91CB3786Bb11656) |
-| PriceConfig        | [`0xf6D5d06A4e8e6904E4360108749C177692F59E90`](https://etherscan.io/address/0xf6D5d06A4e8e6904E4360108749C177692F59E90) |
-| RolesAdmin         | [`0xb216d714d91eeC4F7120a732c11428857C659eC8`](https://etherscan.io/address/0xb216d714d91eeC4F7120a732c11428857C659eC8) |
-| TreasuryCustodian  | [`0xC9518AC915e46D707585116451Dc19c164513Ccf`](https://etherscan.io/address/0xC9518AC915e46D707585116451Dc19c164513Ccf) |
-| Distributor        | [`0x27e606fdb5C922F8213dC588A434BF7583697866`](https://etherscan.io/address/0x27e606fdb5C922F8213dC588A434BF7583697866) |
-| Emergency          | [`0x9229b0b6FA4A58D67Eb465567DaA2c6A34714A75`](https://etherscan.io/address/0x9229b0b6FA4A58D67Eb465567DaA2c6A34714A75) |
-| BondManager        | [`0xf577c77ee3578c7F216327F41B5D7221EaD2B2A3`](https://etherscan.io/address/0xf577c77ee3578c7f216327f41b5d7221ead2b2a3) |
-| BLVaultManagerLido | [`0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23`](https://etherscan.io/address/0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23) |
-| CrossChainBridge   | [`0x45e563c39cddba8699a90078f42353a57509543a`](https://etherscan.io/address/0x45e563c39cddba8699a90078f42353a57509543a) |
+| Contract | Chain | Address |
+| -------- | ----  | ------- |
+| BondCallback       | Mainnet |  [`0xbf2B6E99B0E8D4c96b946c182132f5752eAa55C6`](https://etherscan.io/address/0xbf2B6E99B0E8D4c96b946c182132f5752eAa55C6) |
+| Operator           | Mainnet | [`0x1Ce568DbB34B2631aCDB5B453c3195EA0070EC65`](https://etherscan.io/address/0x1Ce568DbB34B2631aCDB5B453c3195EA0070EC65) |
+| Heart              | Mainnet | [`0x1652b503E0F1CF38b6246Ed3b91CB3786Bb11656`](https://etherscan.io/address/0x1652b503E0F1CF38b6246Ed3b91CB3786Bb11656) |
+| PriceConfig        | Mainnet | [`0xf6D5d06A4e8e6904E4360108749C177692F59E90`](https://etherscan.io/address/0xf6D5d06A4e8e6904E4360108749C177692F59E90) |
+| RolesAdmin         | Mainnet  | [`0xb216d714d91eeC4F7120a732c11428857C659eC8`](https://etherscan.io/address/0xb216d714d91eeC4F7120a732c11428857C659eC8) |
+|                    | Arbitrum | [`0x69168c08AcF66f002fd02E1B169f38C022c93b70`](https://arbiscan.io/address/0x69168c08AcF66f002fd02E1B169f38C022c93b70) |
+| TreasuryCustodian  | Mainnet | [`0xC9518AC915e46D707585116451Dc19c164513Ccf`](https://etherscan.io/address/0xC9518AC915e46D707585116451Dc19c164513Ccf) |
+| Distributor        | Mainnet | [`0x27e606fdb5C922F8213dC588A434BF7583697866`](https://etherscan.io/address/0x27e606fdb5C922F8213dC588A434BF7583697866) |
+| Emergency          | Mainnet | [`0x9229b0b6FA4A58D67Eb465567DaA2c6A34714A75`](https://etherscan.io/address/0x9229b0b6FA4A58D67Eb465567DaA2c6A34714A75) |
+| BondManager        | Mainnet | [`0xf577c77ee3578c7F216327F41B5D7221EaD2B2A3`](https://etherscan.io/address/0xf577c77ee3578c7f216327f41b5d7221ead2b2a3) |
+| BLVaultManagerLido | Mainnet | [`0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23`](https://etherscan.io/address/0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23) |
+| CrossChainBridge   | Mainnet  | [`0x45e563c39cddba8699a90078f42353a57509543a`](https://etherscan.io/address/0x45e563c39cddba8699a90078f42353a57509543a) |
+|                    | Arbitrum | [`0x20B3834091f038Ce04D8686FAC99CA44A0FB285c`](https://arbiscan.io/address/0x20B3834091f038Ce04D8686FAC99CA44A0FB285c) | 
 
 #### Dependencies
 
@@ -47,12 +49,8 @@
 
 ### Arbitrum
 
-#### Policies
 
-| Contract         | Address                                                                                                                |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| RolesAdmin       | [`0x69168c08AcF66f002fd02E1B169f38C022c93b70`](https://arbiscan.io/address/0x69168c08AcF66f002fd02E1B169f38C022c93b70) |
-| CrossChainBridge | [`0x20B3834091f038Ce04D8686FAC99CA44A0FB285c`](https://arbiscan.io/address/0x20B3834091f038Ce04D8686FAC99CA44A0FB285c) |
+### Arbitrum
 
 #### Dependencies
 


### PR DESCRIPTION
This PR introduces a new schema for Contract Addresses section. In particular, it organizes tables around contracts and nests chain-specific address underneath it. This simplifies the lookup while allowing us to scale to many chains.

- [x] Combine V3 contracts into single table
- [x] Combine Goerli section into existing sections
- [x] Combine MS addys in one table
- [x] Reorganize Multisigs, Allocators and Flex Loans sections

The resulting layout looks like this: 

<img width="985" alt="image" src="https://github.com/OlympusDAO/olympus-docs/assets/81924824/169faebd-71e7-4922-94d0-55ef41f95742">
<img width="822" alt="image" src="https://github.com/OlympusDAO/olympus-docs/assets/81924824/e8e38ae4-a8fc-4734-8dbc-59d518fd2cef">
