### PR TITLE
build(deps): migrate to pnpm 11 and patch websocket-driver

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,14 +6,18 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   audit:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   },
   "engines": {
     "node": ">=24",
-    "pnpm": ">=10.33.0",
+    "pnpm": ">=11.13.0",
     "npm": "use-pnpm",
     "yarn": "use-pnpm"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.13.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ overrides:
   trim@<0.0.3: ^0.0.3
   uuid@<11.1.1: ^11.1.1
   wait-on@<9.0.4: ^9.0.4
-  websocket-driver@<0.7.5: 0.7.5
+  websocket-driver@<0.7.5: ^0.7.5
   webpack-bundle-analyzer@4.5.0>ws@>=8.0.0 <8.20.1: ^8.20.1
   webpack-dev-middleware@<5.3.4: ^5.3.4
   webpack-dev-server@<5.2.5: ^5.2.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,7 @@ overrides:
   trim@<0.0.3: ^0.0.3
   uuid@<11.1.1: ^11.1.1
   wait-on@<9.0.4: ^9.0.4
+  websocket-driver@<0.7.5: 0.7.5
   webpack-bundle-analyzer@4.5.0>ws@>=8.0.0 <8.20.1: ^8.20.1
   webpack-dev-middleware@<5.3.4: ^5.3.4
   webpack-dev-server@<5.2.5: ^5.2.5
@@ -69,9 +70,7 @@ overrides:
   yaml@<1.10.3: ^1.10.3
 
 patchedDependencies:
-  gray-matter@4.0.3:
-    hash: 82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f
-    path: patches/gray-matter@4.0.3.patch
+  gray-matter@4.0.3: 82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f
 
 importers:
 
@@ -234,10 +233,6 @@ packages:
     resolution: {integrity: sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.29.7':
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
@@ -388,11 +383,6 @@ packages:
 
   '@babel/parser@7.18.11':
     resolution: {integrity: sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -5429,8 +5419,8 @@ packages:
     peerDependencies:
       webpack: ^5.94.0
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -5603,7 +5593,7 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -5621,7 +5611,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -5636,14 +5626,6 @@ snapshots:
       '@babel/types': 7.18.10
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
-
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
 
   '@babel/generator@7.29.7':
     dependencies:
@@ -5725,7 +5707,7 @@ snapshots:
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -5733,7 +5715,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.6
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -5808,7 +5790,7 @@ snapshots:
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/highlight@7.18.6':
     dependencies:
@@ -5819,10 +5801,6 @@ snapshots:
   '@babel/parser@7.18.11':
     dependencies:
       '@babel/types': 7.18.10
-
-  '@babel/parser@7.29.2':
-    dependencies:
-      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -5906,7 +5884,7 @@ snapshots:
   '@babel/plugin-proposal-object-rest-spread@7.12.1(@babel/core@7.29.6)':
     dependencies:
       '@babel/core': 7.29.6
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.6)
       '@babel/plugin-transform-parameters': 7.18.8(@babel/core@7.29.6)
 
@@ -5994,7 +5972,7 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.12.1(@babel/core@7.29.6)':
     dependencies:
       '@babel/core': 7.29.6
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.29.6)':
     dependencies:
@@ -6019,7 +5997,7 @@ snapshots:
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.6)':
     dependencies:
       '@babel/core': 7.29.6
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.6)':
     dependencies:
@@ -6416,17 +6394,17 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/generator': 7.29.7
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -7277,7 +7255,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.4.0)':
     dependencies:
@@ -9103,7 +9081,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fbemitter@3.0.0:
     dependencies:
@@ -11484,7 +11462,7 @@ snapshots:
     dependencies:
       faye-websocket: 0.11.4
       uuid: 11.1.1
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   sort-css-media-queries@2.0.4: {}
 
@@ -12050,7 +12028,7 @@ snapshots:
       std-env: 3.2.1
       webpack: 5.105.4
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.8
       safe-buffer: 5.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,7 +66,7 @@ overrides:
   "trim@<0.0.3": "^0.0.3"
   "uuid@<11.1.1": "^11.1.1"
   "wait-on@<9.0.4": "^9.0.4"
-  "websocket-driver@<0.7.5": "0.7.5"
+  "websocket-driver@<0.7.5": "^0.7.5"
   "webpack-bundle-analyzer@4.5.0>ws@>=8.0.0 <8.20.1": "^8.20.1"
   "webpack-dev-middleware@<5.3.4": "^5.3.4"
   "webpack-dev-server@<5.2.5": "^5.2.5"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,9 @@ minimumReleaseAgeExclude:
   - "follow-redirects@1.16.0"
   - "http-proxy-middleware@2.0.10" # CVE-2026-55602 patched release, remove after maturity window.
   - "webpack-dev-server@5.2.5" # CVE-2026-9595 patched release, remove after maturity window.
-onlyBuiltDependencies:
-  - "core-js@3.24.1"
-  - "core-js-pure@3.49.0"
+allowBuilds:
+  "core-js@3.24.1": true
+  "core-js-pure@3.49.0": true
 overrides:
   "@babel/core@<=7.29.0": "7.29.6"
   "@babel/helpers@<7.26.10": "^7.26.10"
@@ -66,6 +66,7 @@ overrides:
   "trim@<0.0.3": "^0.0.3"
   "uuid@<11.1.1": "^11.1.1"
   "wait-on@<9.0.4": "^9.0.4"
+  "websocket-driver@<0.7.5": "0.7.5"
   "webpack-bundle-analyzer@4.5.0>ws@>=8.0.0 <8.20.1": "^8.20.1"
   "webpack-dev-middleware@<5.3.4": "^5.3.4"
   "webpack-dev-server@<5.2.5": "^5.2.5"


### PR DESCRIPTION
## Summary

Dependency installs now run on pnpm 11 with its supported default-deny build policy, and the vulnerable `websocket-driver` path is constrained to compatible patched `0.7.x` releases. CI checkouts no longer persist credentials, and workflow permissions are scoped to least privilege.

## Validation

- Clean `pnpm install --no-frozen-lockfile`
- Clean `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level moderate --json` — zero vulnerabilities
- `pnpm run build`
- `pnpm run lint:check`
- `pnpm run typecheck`

The production build succeeded with the repository's pre-existing broken-link warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved workflow security by limiting permissions and preventing checkout credentials from persisting between steps.

* **Chores**
  * Updated the minimum supported pnpm version to 11.13.0.
  * Refined workspace build permissions and updated the `websocket-driver` version constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->