### PR TITLE
docs: update CD redemption borrowing guidance

### DIFF
--- a/docs/overview/09_convertible-deposits.md
+++ b/docs/overview/09_convertible-deposits.md
@@ -651,78 +651,46 @@ When considering convertible deposits, users should consider:
 
 ### Configuration
 
-#### Current Institutional Market Parameters
+The tables below show the configuration progression. Parameters are rows, changes are columns in ascending order, and a blank cell means that parameter was not changed by that update.
 
-- **Minimum Bid**: 100,000 USDS
-- **Standard Tick Capacity**: 100,000 OHM
-- **Tick Price Step**: Each filled tick increases the conversion price by 0.75%
-- **Daily Tick Tiers**: Tick capacity starts at 100,000 OHM and halves each time cumulative daily conversions cross another multiple of the daily target: 100,000, 50,000, 25,000, 12,500 OHM, and so on
+#### Assets
+
+| Parameter                   | Launch                                                  | January 2026                   | January 26, 2026 | OCG Proposal 15          |
+| --------------------------- | ------------------------------------------------------- | ------------------------------ | ---------------- | ------------------------ |
+| Supported Asset             | USDS                                                    |                                |                  |                          |
+| Deposit Periods             | 1, 2, and 3 months                                      | 3 months                       |                  | 6 months                 |
+| Yield Strategy              | USDS deposits earn Sky Savings Rate through sUSDS vault |                                |                  |                          |
+| Minimum Deposit             | 1 USDS                                                  |                                |                  |                          |
+| Deposit Cap                 | 1,000,000 USDS                                          |                                | 2,000,000 USDS   | 60,000,000 USDS          |
+| Maximum Borrow Percentage   | 0%                                                      | 96.7% of the redemption amount |                  |                          |
+| Annual Borrow Interest Rate | 0%                                                      | 5.5%                           |                  |                          |
+| Reclaim Rate                | 90%                                                     | 97.5% for 3-month deposits     |                  | 99% for 6-month deposits |
+
+#### Auction
+
+| Parameter            | Launch                     | January 2026     | January 26, 2026 | OCG Proposal 15                                |
+| -------------------- | -------------------------- | ---------------- | ---------------- | ---------------------------------------------- |
+| Tick Size            | 150 OHM                    |                  |                  | 263,733.160134073 OHM                          |
+| Tick Step Multiplier | 100.75%                    |                  |                  |                                                |
+| Tick Size Base       | 2                          |                  |                  |                                                |
+| Tracking Period      | 7 days                     |                  |                  |                                                |
+| Minimum Bid          | 100 USDS                   |                  |                  | 100,000 USDS                                   |
+| Deposit Periods      | 1, 2, and 3 months enabled | 3 months enabled |                  | 6 months enabled; other known periods disabled |
+
+When daily targets are exceeded, tick capacity adjusts according to the tick size base. With the OCG Proposal 15 configuration, tick capacity starts at 263,733.160134073 OHM and halves each time cumulative daily conversions cross another multiple of the daily target.
+
+#### Emissions
+
+| Parameter            | Launch               | January 2026         | January 26, 2026 | OCG Proposal 15          |
+| -------------------- | -------------------- | -------------------- | ---------------- | ------------------------ |
+| Base Emissions Rate  | 0.02% of supply/day  | 0.04% of supply/day  |                  | 1.3368727% of supply/day |
+| Minimum Price        | 120% of market price | 110% of market price |                  |                          |
+| Backing              | 11.69 USDS/OHM       |                      |                  |                          |
+| Minimum Premium      | 50%                  |                      |                  |                          |
+| Restart Timeframe    | 11 days              |                      |                  |                          |
+| Bond Market Capacity | 0%                   |                      |                  |                          |
 
 The daily target and current tick can change as the market operates. Review the Olympus app's bid preview for the live tick capacity, prices, and weighted-average execution before submitting a bid.
-
-#### Launch Parameters (Historical)
-
-##### Assets
-
-- **Supported Asset**: USDS
-- **Deposit Periods**: 1, 2, and 3 months
-- **Yield Strategy**: USDS deposits earn Sky Savings Rate through sUSDS vault
-- **Minimum Deposit**: 1 USDS
-- **Deposit Cap**: 1,000,000 USDS
-- **Reclaim Rate**: 90% (90% of the deposited amount will be returned upon reclaim)
-
-##### Auction
-
-- **Tick Size**: 150 OHM (halves when daily target is exceeded)
-- **Tick Step Multiplier**: 100.75% (0.75% increase per tick)
-- **Tick Size Base**: 2
-- **Tracking Period**: 7 days
-- **Minimum Bid**: 100 USDS
-
-#### Emission Mechanics
-
-- **Base Emissions Rate**: 0.02% of supply/day
-- **Minimum Price**: 120% of market price
-- **Backing**: 11.69 USDS/OHM
-- **Minimum Premium**: 50% (the market price of OHM must be >= 17.535 USDS/OHM)
-- **Restart Timeframe**: 11 days
-- **Bond Market Capacity**: 0% (there will be no bond market for undersold OHM)
-
-#### January 2026 Parameters (Historical)
-
-##### Assets (January 2026)
-
-- **Supported Asset**: USDS
-- **Deposit Periods**: 3 months _(changed from: 1, 2, and 3 months)_
-- **Yield Strategy**: USDS deposits earn Sky Savings Rate through sUSDS vault
-- **Minimum Deposit**: 1 USDS
-- **Deposit Cap**: 1,000,000 USDS
-- **Maximum Borrow Percentage**: 96.7% of the redemption amount
-- **Annual Borrow Interest Rate**: 5.5%
-- **Reclaim Rate**: 97.5% (97.5% of the deposited amount will be returned upon reclaim for 3-month deposits) _(changed from: 90%)_
-
-##### Auction (January 2026)
-
-- **Tick Size**: 150 OHM (halves when daily target is exceeded)
-- **Tick Step Multiplier**: 100.75% (0.75% increase per tick)
-- **Tick Size Base**: 2
-- **Tracking Period**: 7 days
-- **Minimum Bid**: 100 USDS
-
-##### Emission Mechanics (January 2026)
-
-- **Base Emissions Rate**: 0.04% of supply/day _(changed from: 0.02% of supply/day)_
-- **Minimum Price**: 110% of market price _(changed from: 120% of market price)_
-- **Backing**: 11.69 USDS/OHM
-- **Minimum Premium**: 50% (the market price of OHM must be >= 17.535 USDS/OHM)
-- **Restart Timeframe**: 11 days
-- **Bond Market Capacity**: 0% (there will be no bond market for undersold OHM)
-
-#### January 26, 2026 Parameter Change (Historical)
-
-##### Assets (January 26, 2026)
-
-- **Deposit Cap**: 2,000,000 USDS _(increased from: 1,000,000 USDS)_
 
 ### Common Questions
 

--- a/docs/overview/09_convertible-deposits.md
+++ b/docs/overview/09_convertible-deposits.md
@@ -651,7 +651,7 @@ When considering convertible deposits, users should consider:
 
 ### Configuration
 
-#### Initial Parameters
+#### Launch Parameters (Historical)
 
 ##### Assets
 
@@ -679,7 +679,7 @@ When considering convertible deposits, users should consider:
 - **Restart Timeframe**: 11 days
 - **Bond Market Capacity**: 0% (there will be no bond market for undersold OHM)
 
-#### Parameters (January 2026)
+#### January 2026 Parameters (Historical)
 
 ##### Assets (January 2026)
 
@@ -709,7 +709,7 @@ When considering convertible deposits, users should consider:
 - **Restart Timeframe**: 11 days
 - **Bond Market Capacity**: 0% (there will be no bond market for undersold OHM)
 
-#### Parameters (January 26, 2026)
+#### January 26, 2026 Parameter Change (Historical)
 
 ##### Assets (January 26, 2026)
 

--- a/docs/overview/09_convertible-deposits.md
+++ b/docs/overview/09_convertible-deposits.md
@@ -363,7 +363,7 @@ While a redemption is in progress, users can borrow against the committed amount
 - **Loan Amount**: Borrow up to the configured percentage of the redemption amount
 - **Fixed Interest**: Interest is calculated from the configured annual rate and the redemption period
 - **Collateralized**: The active redemption secures the loan through the receipt tokens held in the redemption vault
-- **No Price-Based Liquidation**: Redemption loans are not liquidated because of OHM or receipt-token market-price changes; default is based on the loan due date and unpaid principal
+- **No Price-Based Liquidation**: Redemption loans are not liquidated because of OHM or receipt-token market-price changes; default is based on the loan due date and an unpaid loan balance (principal and interest)
 
 ##### Repayment Process
 
@@ -387,7 +387,7 @@ While a redemption is in progress, users can borrow against the committed amount
 ##### Important Borrowing Restrictions
 
 - **No Redemption While Borrowing**: Users cannot complete their redemption while they have an open loan
-- **No Cancellation While Borrowing**: Users cannot cancel their redemption while they have unpaid principal
+- **No Cancellation While Borrowing**: Users cannot cancel their redemption while they have an unpaid loan balance (principal and interest)
 - **Must Repay First**: Repay the outstanding principal and interest before completing or cancelling redemption
 - **Single Loan**: For a given redemption, only one loan can be taken
 - **Conversion Requires Cancellation**: Receipt tokens securing an active redemption cannot be converted to OHM. To convert, borrowers must repay the loan, cancel the redemption to recover the receipt tokens and position, then use the conversion flow if the position is still eligible.

--- a/docs/overview/09_convertible-deposits.md
+++ b/docs/overview/09_convertible-deposits.md
@@ -222,7 +222,7 @@ The quantity of stablecoins to deposit
 
 ##### Deposit Period
 
-Select from available periods (currently 1, 2, or 3 months)
+Select from the deposit periods currently enabled by governance.
 
 ##### Minimum OHM Out
 
@@ -420,7 +420,7 @@ Limit orders operate through a separate contract (`CDAuctioneerLimitOrders`) tha
 
 When creating a limit order, users specify:
 
-1. **Deposit Period**: Choose from available periods (1, 2, or 3 months)
+1. **Deposit Period**: Choose from the currently enabled deposit periods
 2. **Deposit Budget**: Total deposit asset to spend on convertible deposits
 3. **Incentive Budget**: Deposit asset to pay solvers as rewards for filling the order
 4. **Maximum Price**: Highest acceptable execution price (deposit asset per OHM)
@@ -655,40 +655,40 @@ The tables below show the configuration progression. Parameters are rows, change
 
 #### Assets
 
-| Parameter                   | Launch                                                  | January 2026                   | January 26, 2026 | OCG Proposal 15          |
-| --------------------------- | ------------------------------------------------------- | ------------------------------ | ---------------- | ------------------------ |
-| Supported Asset             | USDS                                                    |                                |                  |                          |
-| Deposit Periods             | 1, 2, and 3 months                                      | 3 months                       |                  | 6 months                 |
-| Yield Strategy              | USDS deposits earn Sky Savings Rate through sUSDS vault |                                |                  |                          |
-| Minimum Deposit             | 1 USDS                                                  |                                |                  |                          |
-| Deposit Cap                 | 1,000,000 USDS                                          |                                | 2,000,000 USDS   | 60,000,000 USDS          |
-| Maximum Borrow Percentage   | 0%                                                      | 96.7% of the redemption amount |                  |                          |
-| Annual Borrow Interest Rate | 0%                                                      | 5.5%                           |                  |                          |
-| Reclaim Rate                | 90%                                                     | 97.5% for 3-month deposits     |                  | 99% for 6-month deposits |
+| Parameter                   | Launch                                                  | January 2026                   | January 26, 2026 | OCG Proposal 15 (July 2026) | MS Batch 1948 (July 16, 2026) |
+| --------------------------- | ------------------------------------------------------- | ------------------------------ | ---------------- | --------------------------- | ----------------------------- |
+| Supported Asset             | USDS                                                    |                                |                  |                             |                               |
+| Deposit Periods             | 1, 2, and 3 months                                      | 3 months only                  |                  | Add 6 months                |                               |
+| Yield Strategy              | USDS deposits earn Sky Savings Rate through sUSDS vault |                                |                  |                             |                               |
+| Minimum Deposit             | 1 USDS                                                  |                                |                  |                             |                               |
+| Deposit Cap                 | 1,000,000 USDS                                          |                                | 2,000,000 USDS   | 60,000,000 USDS             |                               |
+| Maximum Borrow Percentage   | 0%                                                      | 96.7% of the redemption amount |                  |                             |                               |
+| Annual Borrow Interest Rate | 0%                                                      | 5.5%                           |                  |                             |                               |
+| Reclaim Rate                | 90%                                                     | 97.5% for 3-month deposits     |                  | 99% for 6-month deposits    |                               |
 
 #### Auction
 
-| Parameter            | Launch                     | January 2026     | January 26, 2026 | OCG Proposal 15                                |
-| -------------------- | -------------------------- | ---------------- | ---------------- | ---------------------------------------------- |
-| Tick Size            | 150 OHM                    |                  |                  | 263,733.160134073 OHM                          |
-| Tick Step Multiplier | 100.75%                    |                  |                  |                                                |
-| Tick Size Base       | 2                          |                  |                  |                                                |
-| Tracking Period      | 7 days                     |                  |                  |                                                |
-| Minimum Bid          | 100 USDS                   |                  |                  | 100,000 USDS                                   |
-| Deposit Periods      | 1, 2, and 3 months enabled | 3 months enabled |                  | 6 months enabled; other known periods disabled |
+| Parameter            | Launch                     | January 2026                        | January 26, 2026 | OCG Proposal 15 (July 2026)         | MS Batch 1948 (July 16, 2026) |
+| -------------------- | -------------------------- | ----------------------------------- | ---------------- | ----------------------------------- | ----------------------------- |
+| Tick Size            | 150 OHM                    |                                     |                  | 263,733.160134073 OHM               | 100,000 OHM                   |
+| Tick Step Multiplier | 100.75%                    |                                     |                  |                                     |                               |
+| Tick Size Base       | 2                          |                                     |                  |                                     |                               |
+| Tracking Period      | 7 days                     |                                     |                  |                                     |                               |
+| Minimum Bid          | 100 USDS                   |                                     |                  | 100,000 USDS                        |                               |
+| Deposit Periods      | 1, 2, and 3 months enabled | 1 and 2 months disabled; 3m remains |                  | 6 months enabled; 3 months disabled |                               |
 
-When daily targets are exceeded, tick capacity adjusts according to the tick size base. With the OCG Proposal 15 configuration, tick capacity starts at 263,733.160134073 OHM and halves each time cumulative daily conversions cross another multiple of the daily target.
+When daily targets are exceeded, tick capacity adjusts according to the tick size base. With the current MS Batch 1948 configuration, tick capacity starts at 100,000 OHM and halves each time cumulative daily conversions cross another multiple of the daily target.
 
 #### Emissions
 
-| Parameter            | Launch               | January 2026         | January 26, 2026 | OCG Proposal 15          |
-| -------------------- | -------------------- | -------------------- | ---------------- | ------------------------ |
-| Base Emissions Rate  | 0.02% of supply/day  | 0.04% of supply/day  |                  | 1.3368727% of supply/day |
-| Minimum Price        | 120% of market price | 110% of market price |                  |                          |
-| Backing              | 11.69 USDS/OHM       |                      |                  |                          |
-| Minimum Premium      | 50%                  |                      |                  |                          |
-| Restart Timeframe    | 11 days              |                      |                  |                          |
-| Bond Market Capacity | 0%                   |                      |                  |                          |
+| Parameter            | Launch               | January 2026         | January 26, 2026 | OCG Proposal 15 (July 2026) | MS Batch 1948 (July 16, 2026) |
+| -------------------- | -------------------- | -------------------- | ---------------- | --------------------------- | ----------------------------- |
+| Base Emissions Rate  | 0.02% of supply/day  | 0.04% of supply/day  |                  | 1.3368727% of supply/day    |                               |
+| Minimum Price        | 120% of market price | 110% of market price |                  |                             |                               |
+| Backing              | 11.69 USDS/OHM       |                      |                  |                             |                               |
+| Minimum Premium      | 50%                  |                      |                  |                             |                               |
+| Restart Timeframe    | 11 days              |                      |                  |                             |                               |
+| Bond Market Capacity | 0%                   |                      |                  |                             |                               |
 
 The daily target and current tick can change as the market operates. Review the Olympus app's bid preview for the live tick capacity, prices, and weighted-average execution before submitting a bid.
 
@@ -737,7 +737,7 @@ A: Yes. Receipt token holders can start redemption and borrow against the active
 A: Yes, the convertible deposit position can be wrapped to an ERC721 NFT, allowing it to be traded on NFT marketplaces.
 
 **Q: Will there be different options for CDs with various strike prices or lengths?**
-A: The conversion price is determined through auction results at the time of purchase, while the deposit period is defined by governance. Users can choose from available periods (1, 2, or 3 months).
+A: The conversion price is determined through auction results at the time of purchase, while the deposit period is defined by governance. Users can choose from the periods currently enabled by governance.
 
 **Q: Will "looping" be easy for regular users?**
 A: Looping is generally an advanced-user action. While it's possible, it isn't currently implemented in the interface and is more suited for sophisticated users.

--- a/docs/overview/09_convertible-deposits.md
+++ b/docs/overview/09_convertible-deposits.md
@@ -356,19 +356,21 @@ After the appropriate period completes:
 
 #### Borrowing Against Redemptions
 
-While a redemption is in progress, users can borrow against the committed amount. Note: Borrowing functionality is disabled in the initial rollout and will be enabled in a future update.
+While a redemption is in progress, users can borrow against the committed amount. Borrowing is available for authorized assets and facilities configured in the Deposit Redemption Vault. The Olympus app displays the current borrow percentage, annual interest rate, and expected loan terms before users borrow.
 
 ##### How Borrowing Works
 
-- **Loan Amount**: Borrow up to a configured percentage of the redemption amount
-- **Fixed Interest**: Loans have fixed interest rates matching the redemption period
-- **Collateralized**: The active redemption serves as collateral
+- **Loan Amount**: Borrow up to the configured percentage of the redemption amount
+- **Fixed Interest**: Interest is calculated from the configured annual rate and the redemption period
+- **Collateralized**: The active redemption secures the loan through the receipt tokens held in the redemption vault
+- **No Price-Based Liquidation**: Redemption loans are not liquidated because of OHM or receipt-token market-price changes; default is based on the loan due date and unpaid principal
 
 ##### Repayment Process
 
 - **Interest First**: Repayments first cover interest, then principal
 - **Protocol Fees**: Interest payments go to the protocol treasury
 - **Flexible Timing**: Users can repay at any time during the loan period
+- **Receipt Tokens Stay Locked**: Repayment reduces the loan, but receipt tokens are only returned through cancelling the redemption or consumed when finishing redemption
 
 ##### Loan Extensions
 
@@ -385,8 +387,10 @@ While a redemption is in progress, users can borrow against the committed amount
 ##### Important Borrowing Restrictions
 
 - **No Redemption While Borrowing**: Users cannot complete their redemption while they have an open loan
-- **Must Repay First**: Either repay the loan in full or wait for it to default before completing redemption
+- **No Cancellation While Borrowing**: Users cannot cancel their redemption while they have unpaid principal
+- **Must Repay First**: Repay the outstanding principal and interest before completing or cancelling redemption
 - **Single Loan**: For a given redemption, only one loan can be taken
+- **Conversion Requires Cancellation**: Receipt tokens securing an active redemption cannot be converted to OHM. To convert, borrowers must repay the loan, cancel the redemption to recover the receipt tokens and position, then use the conversion flow if the position is still eligible.
 
 ##### Borrowing Benefits
 
@@ -656,8 +660,7 @@ When considering convertible deposits, users should consider:
 - **Yield Strategy**: USDS deposits earn Sky Savings Rate through sUSDS vault
 - **Minimum Deposit**: 1 USDS
 - **Deposit Cap**: 1,000,000 USDS
-- **Maximum Borrow Percentage**: 0% (disabled at launch, will be enabled in future update)
-- **Annual Borrow Interest Rate**: 0% (disabled at launch, will be enabled in future update)
+- **Borrowing Terms**: Borrowing was not enabled in the initial configuration. See the current parameters below and the Olympus app for live borrowing terms.
 - **Reclaim Rate**: 90% (90% of the deposited amount will be returned upon reclaim)
 
 ##### Auction
@@ -686,8 +689,7 @@ When considering convertible deposits, users should consider:
 - **Yield Strategy**: USDS deposits earn Sky Savings Rate through sUSDS vault
 - **Minimum Deposit**: 1 USDS
 - **Deposit Cap**: 1,000,000 USDS
-- **Max Borrow Percentage**: 96.7% (maximum borrow percentage of redemption amount) _(changed from: 0%)_
-- **Annual Borrow Interest Rate**: 5.5% (fixed interest rate for borrowing) _(changed from: 0%)_
+- **Borrowing Terms**: Borrowing against active redemptions is enabled. The max borrow percentage and annual interest rate are configured on-chain and shown in the Olympus app before borrowing.
 - **Reclaim Rate**: 97.5% (97.5% of the deposited amount will be returned upon reclaim for 3-month deposits) _(changed from: 90%)_
 
 ##### Auction (January 2026)
@@ -727,7 +729,7 @@ A: Longer periods give more time for profitable conversions but reduce flexibili
 A: Yes, through early reclaim (with discount) or redemption (with waiting period). The conversion price cannot be changed once set.
 
 **Q: What can I do with my receipt tokens before expiry?**
-A: You can exchange the receipt tokens in a liquidity pool, reclaim the deposit (with a discount), redeem the deposit (waiting period), or redeem the deposit and borrow against it once borrowing is enabled.
+A: You can exchange the receipt tokens in a liquidity pool, reclaim the deposit (with a discount), redeem the deposit (waiting period), or start redemption and borrow against the active redemption if the asset and facility are configured for borrowing.
 
 **Q: Will USDS deposits be lent out to earn yield?**
 A: USDS deposits are deposited into the sUSDS vault to earn the Sky Savings Rate. The goal is to maintain a low-risk approach while generating yield for the protocol.
@@ -752,7 +754,7 @@ A: Yes, if wrapped as an ERC721 NFT. Receipt tokens are also transferable. The n
 A: Users can still get their full deposit back through redemption, or exit early through reclaim (with discount).
 
 **Q: Will Olympus offer borrowing against receipt tokens?**
-A: Yes, borrowing functionality will be available to receipt token holders when they start the redemption process. This feature is planned for implementation after the initial launch.
+A: Yes. Receipt token holders can start redemption and borrow against the active redemption when the relevant asset and facility are configured in the Deposit Redemption Vault.
 
 **Q: Can the CD position be traded as an NFT?**
 A: Yes, the convertible deposit position can be wrapped to an ERC721 NFT, allowing it to be traded on NFT marketplaces.
@@ -772,7 +774,7 @@ A: The protocol benefits from various outcomes: conversions provide OHM distribu
 A: Without position: wait full deposit period from start date. With position: wait only until conversion expiry (could be immediate if expired).
 
 **Q: Can I borrow against my redemptions?**
-A: Borrowing functionality is disabled in the initial rollout and will be enabled in a future update. Once enabled, borrowing will be limited to a configured percentage of the redemption amount (typically less than 100%).
+A: Yes, when the relevant asset and facility are configured for borrowing. The app shows the current max borrow percentage, annual interest rate, principal, interest, and due date before borrowing. Redemption loans are secured by the active redemption and are not liquidated based on market-price moves, but they can default if unpaid after the due date.
 
 **Q: What happens if I default on a borrowing loan?**
 A: Third parties can claim the default for a reward. Users keep any principal repaid, but lose the remainder to the protocol.

--- a/docs/overview/09_convertible-deposits.md
+++ b/docs/overview/09_convertible-deposits.md
@@ -660,7 +660,6 @@ When considering convertible deposits, users should consider:
 - **Yield Strategy**: USDS deposits earn Sky Savings Rate through sUSDS vault
 - **Minimum Deposit**: 1 USDS
 - **Deposit Cap**: 1,000,000 USDS
-- **Borrowing Terms**: Borrowing was not enabled in the initial configuration. See the current parameters below and the Olympus app for live borrowing terms.
 - **Reclaim Rate**: 90% (90% of the deposited amount will be returned upon reclaim)
 
 ##### Auction
@@ -689,7 +688,8 @@ When considering convertible deposits, users should consider:
 - **Yield Strategy**: USDS deposits earn Sky Savings Rate through sUSDS vault
 - **Minimum Deposit**: 1 USDS
 - **Deposit Cap**: 1,000,000 USDS
-- **Borrowing Terms**: Borrowing against active redemptions is enabled. The max borrow percentage and annual interest rate are configured on-chain and shown in the Olympus app before borrowing.
+- **Maximum Borrow Percentage**: 96.7% of the redemption amount
+- **Annual Borrow Interest Rate**: 5.5%
 - **Reclaim Rate**: 97.5% (97.5% of the deposited amount will be returned upon reclaim for 3-month deposits) _(changed from: 90%)_
 
 ##### Auction (January 2026)

--- a/docs/overview/09_convertible-deposits.md
+++ b/docs/overview/09_convertible-deposits.md
@@ -651,6 +651,15 @@ When considering convertible deposits, users should consider:
 
 ### Configuration
 
+#### Current Institutional Market Parameters
+
+- **Minimum Bid**: 100,000 USDS
+- **Standard Tick Capacity**: 100,000 OHM
+- **Tick Price Step**: Each filled tick increases the conversion price by 0.75%
+- **Daily Tick Tiers**: Tick capacity starts at 100,000 OHM and halves each time cumulative daily conversions cross another multiple of the daily target: 100,000, 50,000, 25,000, 12,500 OHM, and so on
+
+The daily target and current tick can change as the market operates. Review the Olympus app's bid preview for the live tick capacity, prices, and weighted-average execution before submitting a bid.
+
 #### Launch Parameters (Historical)
 
 ##### Assets

--- a/docs/overview/09_convertible-deposits.md
+++ b/docs/overview/09_convertible-deposits.md
@@ -658,7 +658,7 @@ The tables below show the configuration progression. Parameters are rows, change
 | Parameter                   | Launch                                                  | January 2026                   | January 26, 2026 | OCG Proposal 15 (July 2026) | MS Batch 1948 (July 16, 2026) |
 | --------------------------- | ------------------------------------------------------- | ------------------------------ | ---------------- | --------------------------- | ----------------------------- |
 | Supported Asset             | USDS                                                    |                                |                  |                             |                               |
-| Deposit Periods             | 1, 2, and 3 months                                      | 3 months only                  |                  | Add 6 months                |                               |
+| Deposit Periods             | 1, 2, and 3 months                                      | 3 months only                  |                  | 6 months only               |                               |
 | Yield Strategy              | USDS deposits earn Sky Savings Rate through sUSDS vault |                                |                  |                             |                               |
 | Minimum Deposit             | 1 USDS                                                  |                                |                  |                             |                               |
 | Deposit Cap                 | 1,000,000 USDS                                          |                                | 2,000,000 USDS   | 60,000,000 USDS             |                               |


### PR DESCRIPTION
## Summary

- update Convertible Deposits docs to say redemption borrowing is live for configured assets/facilities
- replace stale launch-disabled language with current-term guidance that points users to the Olympus app/on-chain config
- clarify redemption-loan collateral, no price-based liquidation behavior, repayment/cancellation restrictions, and the conversion path after borrowing

## Verification

Live on-chain check at Ethereum block `25554328` against:

- DepositRedemptionVault: `0x20a3d8510f2e1176E8Db4CeA9883a8287a9029Db`
- ConvertibleDepositFacility: `0xEBDe552D851DD6Dfd3D360C596D3F4aF6e5F9678`
- USDS: `0xdC035D45d973E3EC169d2276DDab16f1e407384F`

Returned:

- `DepositRedemptionVault.isEnabled() == true`
- `ConvertibleDepositFacility.isEnabled() == true`
- `isAuthorizedFacility(ConvertibleDepositFacility) == true`
- `getMaxBorrowPercentage(USDS, ConvertibleDepositFacility) == 9670` bps (`96.7%`)
- `getAnnualInterestRate(USDS, ConvertibleDepositFacility) == 550` bps (`5.5%`)

Implementation references:

- `DepositRedemptionVault.borrowAgainstRedemption()` creates a loan against an existing redemption, computes principal from the configured max borrow percentage, and computes interest from the configured annual rate and redemption period.
- `cancelRedemption()` and `finishRedemption()` both revert while unpaid principal remains.
- `repayLoan()` pays interest first, then principal, and receipt tokens are only returned through cancellation or consumed when finishing redemption.
- `claimDefaultedLoan()` defaults based on due date/unpaid principal, not market price movement.
- `setMaxBorrowPercentage()` and `setAnnualInterestRate()` are on-chain configured per asset/facility, so user-facing docs should point to live terms instead of hardcoding volatile parameters.

Checks run:

- `pnpm exec prettier --check docs/overview/09_convertible-deposits.md`
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm build`

Note: `pnpm build` passes and reports pre-existing broken links outside the edited page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance on borrowing against redemptions, including eligibility based on configured assets/facilities and the way the app shows current borrow percentage, annual interest rate, and expected loan terms before borrowing.
  * Clarified loan behavior and repayment rules, including no liquidation due to price changes and interest-first repayment, with users able to repay anytime during the loan period.
  * Strengthened borrowing restrictions for cancellation/default scenarios (including one-loan-per-redemption limits) and updated configuration/FAQs to reflect governance-enabled deposit-period wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->