### PR TITLE
fix(deps): remediate current pnpm audit findings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
   braces@<3.0.3: ^3.0.3
   cookie@<0.7.0: ^0.7.0
   express@<4.19.2: ^4.19.2
-  fast-uri@<3.1.2: ^3.1.2
+  fast-uri@<3.1.4: ^3.1.4
   follow-redirects@<1.16.0: ^1.16.0
   form-data@>=4.0.0 <4.0.6: 4.0.6
   glob@<10.5.0: ^10.5.0
@@ -31,6 +31,7 @@ overrides:
   js-yaml@<4.3.0: 4.3.0
   katex@<0.16.21: ^0.16.21
   launch-editor@<=2.14.0: 2.14.1
+  linkify-it@<=5.0.1: 5.0.2
   loader-utils@<2.0.4: 2.0.4
   lodash@<4.18.0: ^4.18.0
   markdown-it@<=14.1.1: 14.2.0
@@ -56,7 +57,7 @@ overrides:
   shell-quote@>=1.1.0 <=1.8.4: ^1.10.0
   smol-toml@<1.6.1: ^1.6.1
   stylis@<4.3.0: ^4.3.0
-  svgo@<2.8.1: ^2.8.1
+  svgo@<2.8.3: ^2.8.3
   trim@<0.0.3: ^0.0.3
   uuid@<11.1.1: ^11.1.1
   wait-on@<9.0.4: ^9.0.4
@@ -2811,8 +2812,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-url-parser@1.1.3:
     resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
@@ -3543,8 +3544,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
@@ -5019,8 +5020,8 @@ packages:
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
-  svgo@2.8.2:
-    resolution: {integrity: sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==}
+  svgo@2.8.3:
+    resolution: {integrity: sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
@@ -7611,7 +7612,7 @@ snapshots:
       '@svgr/core': 6.3.1
       cosmiconfig: 7.0.1
       deepmerge: 4.2.2
-      svgo: 2.8.2
+      svgo: 2.8.3
 
   '@svgr/webpack@6.3.1':
     dependencies:
@@ -7945,7 +7946,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9081,7 +9082,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fast-url-parser@1.1.3:
     dependencies:
@@ -9820,7 +9821,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.1:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -9891,7 +9892,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -10830,7 +10831,7 @@ snapshots:
     dependencies:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
-      svgo: 2.8.2
+      svgo: 2.8.3
 
   postcss-unique-selectors@5.1.1(postcss@8.5.14):
     dependencies:
@@ -11602,7 +11603,7 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
-  svgo@2.8.2:
+  svgo@2.8.3:
     dependencies:
       commander: 7.2.0
       css-select: 4.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 blockExoticSubdeps: true
 engineStrict: true
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - "fast-uri@3.1.4" # GHSA-4c8g-83qw-93j6 and GHSA-v2hh-gcrm-f6hx patched release; remove after maturity window.
 allowBuilds:
   "core-js@3.24.1": true
   "core-js-pure@3.49.0": true
@@ -21,7 +23,7 @@ overrides:
   "braces@<3.0.3": "^3.0.3"
   "cookie@<0.7.0": "^0.7.0"
   "express@<4.19.2": "^4.19.2"
-  "fast-uri@<3.1.2": "^3.1.2"
+  "fast-uri@<3.1.4": "^3.1.4"
   "follow-redirects@<1.16.0": "^1.16.0"
   "form-data@>=4.0.0 <4.0.6": "4.0.6"
   "glob@<10.5.0": "^10.5.0"
@@ -31,6 +33,7 @@ overrides:
   "js-yaml@<4.3.0": "4.3.0"
   "katex@<0.16.21": "^0.16.21"
   "launch-editor@<=2.14.0": "2.14.1"
+  "linkify-it@<=5.0.1": "5.0.2"
   "loader-utils@<2.0.4": "2.0.4"
   "lodash@<4.18.0": "^4.18.0"
   "markdown-it@<=14.1.1": "14.2.0"
@@ -56,7 +59,7 @@ overrides:
   "shell-quote@>=1.1.0 <=1.8.4": "^1.10.0"
   "smol-toml@<1.6.1": "^1.6.1"
   "stylis@<4.3.0": "^4.3.0"
-  "svgo@<2.8.1": "^2.8.1"
+  "svgo@<2.8.3": "^2.8.3"
   "trim@<0.0.3": "^0.0.3"
   "uuid@<11.1.1": "^11.1.1"
   "wait-on@<9.0.4": "^9.0.4"


### PR DESCRIPTION
## Summary

Clears the current moderate-or-higher pnpm audit findings while preserving the repository's pnpm 11 supply-chain controls. The patched `fast-uri` release is temporarily exempted from the seven-day release-age gate because it resolves two active high-severity advisories; the exception can be removed after the maturity window.

## Validation

- `pnpm install --no-frozen-lockfile` from a clean install state
- `pnpm install --frozen-lockfile` from a clean install state
- `pnpm audit --audit-level moderate` (no moderate-or-higher findings; two low findings remain locally)
- `pnpm run typecheck`
- `pnpm run lint:check`
- `pnpm run build` (passes with pre-existing broken-link warnings)
- pnpm 11 workspace-policy invariant check
- Local CodeRabbit review of committed changes (zero findings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency policies to allow newer patched versions of several packages.
  * Added an exception for a specific package release to maintain installation compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->