### PR TITLE
fix(deps): remediate nanoid advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ overrides:
   mermaid@<10.9.8: 10.9.8
   micromatch@<4.0.8: ^4.0.8
   minimatch@<10.2.6: 10.2.6
-  nanoid@<3.3.17: ^3.3.17
+  nanoid@<3.3.18: ^3.3.18
   node-forge@<1.4.0: ^1.4.0
   on-headers@<1.1.0: ^1.1.0
   path-to-regexp@<3.3.0: ^3.3.0
@@ -3909,8 +3909,8 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10645,7 +10645,7 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
 
@@ -11084,7 +11084,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,6 @@ minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - "dompurify@3.4.13" # GHSA-55q2-fjhq-7xh7 patched release; remove after maturity window.
   - "mermaid@10.9.8" # GHSA-2v8p-3f2j-5mp7, GHSA-6x64-9x62-f2gx and GHSA-c4c3-pg64-4m4v patched release; remove after maturity window.
-  - "nanoid@3.3.17" # GHSA-2v37-7h3g-55p8 patched release; remove after maturity window.
 auditConfig:
   ignoreGhsas:
     # image-size DoS via infinite loops in the ICNS/JXL/HEIF parsers. Both advisories cover
@@ -53,7 +52,7 @@ overrides:
   "mermaid@<10.9.8": "10.9.8"
   "micromatch@<4.0.8": "^4.0.8"
   "minimatch@<10.2.6": "10.2.6"
-  "nanoid@<3.3.17": "^3.3.17"
+  "nanoid@<3.3.18": "^3.3.18"
   "node-forge@<1.4.0": "^1.4.0"
   "on-headers@<1.1.0": "^1.1.0"
   "path-to-regexp@<3.3.0": "^3.3.0"


### PR DESCRIPTION
## Summary
- Remediate the `nanoid` security advisory by enforcing patched version `3.3.18`.
- Remove the temporary `nanoid@3.3.17` release-age exception.
- Refresh the lockfile resolution and integrity metadata.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm audit --json` — no advisories reported
- `pnpm why nanoid` — only `nanoid@3.3.18` is installed
- `pnpm lint:check`
- `pnpm typecheck`
- GitHub Actions `build` jobs — passed
- Local `pnpm build` — client compilation passed, but the server build exceeded the local timeout

## Risk
Dependency metadata and lockfile changes only; no application source changes.